### PR TITLE
GH-132 Change tests to use random high listening port instead of 80

### DIFF
--- a/reposilite-backend/src/test/java/org/panda_lang/reposilite/ReposiliteIntegrationTest.java
+++ b/reposilite-backend/src/test/java/org/panda_lang/reposilite/ReposiliteIntegrationTest.java
@@ -14,10 +14,12 @@ import org.panda_lang.utilities.commons.function.ThrowingRunnable;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Random;
 
 public abstract class ReposiliteIntegrationTest {
 
     protected static final HttpRequestFactory requestFactory = new NetHttpTransport().createRequestFactory();
+    public static final String testPort = String.valueOf(new Random().nextInt(16383) + 49152);
 
     @TempDir
     protected File workingDirectory;
@@ -30,12 +32,20 @@ public abstract class ReposiliteIntegrationTest {
     }
 
     protected Reposilite reposilite(File workingDirectory, String... args) throws IOException {
-        FileUtils.copyDirectory(new File("src/test/workspace/repositories"), new File(workingDirectory, "repositories"));
+        return reposilite(testPort, workingDirectory, args);
+    }
 
-        return ReposiliteLauncher.create(ArrayUtils.mergeArrays(args, ArrayUtils.of(
-                "--working-directory=" + workingDirectory.getAbsolutePath(),
-                "--test-env"
-        ))).orElseThrow(() -> new RuntimeException("Invalid test parameters"));
+    protected Reposilite reposilite(String port, File workingDirectory, String... args) throws IOException {
+        FileUtils.copyDirectory(new File("src/test/workspace/repositories"), new File(workingDirectory, "repositories"));
+        System.setProperty("reposilite.port", port);
+        try {
+            return ReposiliteLauncher.create(ArrayUtils.mergeArrays(args, ArrayUtils.of(
+                    "--working-directory=" + workingDirectory.getAbsolutePath(),
+                    "--test-env"
+            ))).orElseThrow(() -> new RuntimeException("Invalid test parameters"));
+        } finally {
+            System.clearProperty("reposilite.port");
+        }
     }
 
     @AfterEach
@@ -65,7 +75,7 @@ public abstract class ReposiliteIntegrationTest {
     }
 
     protected GenericUrl url(String uri) {
-        return new GenericUrl("http://localhost:80" + uri);
+        return new GenericUrl("http://localhost:" + testPort + uri);
     }
 
 }

--- a/reposilite-backend/src/test/java/org/panda_lang/reposilite/ReposiliteLauncherTest.java
+++ b/reposilite-backend/src/test/java/org/panda_lang/reposilite/ReposiliteLauncherTest.java
@@ -38,10 +38,12 @@ class ReposiliteLauncherTest {
 
         try {
             System.setProperty("reposilite.debugEnabled", "true");
+            System.setProperty("reposilite.port", ReposiliteIntegrationTest.testPort);
             ReposiliteLauncher.main("-wd=" + workingDirectory.getAbsolutePath());
         }
         finally {
             System.clearProperty("reposilite.debugEnabled");
+            System.clearProperty("reposilite.port");
         }
 
         assertTrue(ReposiliteWriter.contains("Debug enabled"));

--- a/reposilite-backend/src/test/java/org/panda_lang/reposilite/console/CliControllerTest.java
+++ b/reposilite-backend/src/test/java/org/panda_lang/reposilite/console/CliControllerTest.java
@@ -90,7 +90,7 @@ class CliControllerTest extends ReposiliteIntegrationTest {
             @Override
             public void onWebSocketClose(int statusCode, String reason) { }
 
-        }, new URI("ws://localhost:80/api/cli"), clientUpgradeRequest).get();
+        }, new URI("ws://localhost:"+testPort+"/api/cli"), clientUpgradeRequest).get();
     }
 
 }

--- a/reposilite-backend/src/test/java/org/panda_lang/reposilite/repository/LookupControllerTest.java
+++ b/reposilite-backend/src/test/java/org/panda_lang/reposilite/repository/LookupControllerTest.java
@@ -97,11 +97,11 @@ class LookupControllerTest extends ReposiliteIntegrationTest {
 
     @Test
     void shouldReturn200AndProxiedFile() throws Exception {
-        super.reposilite.getConfiguration().setProxied(Collections.singletonList("http://localhost:8080"));
+        String proxyPort = String.valueOf(Integer.parseInt(testPort)+1);
+        super.reposilite.getConfiguration().setProxied(Collections.singletonList("http://localhost:"+proxyPort));
 
         try {
-            System.setProperty("reposilite.port", "8080");
-            Reposilite proxiedReposilite = super.reposilite(proxiedWorkingDirectory);
+            Reposilite proxiedReposilite = super.reposilite(proxyPort, proxiedWorkingDirectory);
             proxiedReposilite.launch();
 
             File proxiedFile = new File(proxiedWorkingDirectory, "/repositories/releases/proxiedGroup/proxiedArtifact/proxied.txt");


### PR DESCRIPTION
The tests use by default port 80 which raises two issues : it needs root privileges and may be already in use by an existing web server. This patch generates a random port between 49152 and 65534 to run the tests and fix several ones for this new behaviour

There are several ways to fix the original issue : I've chosen to pick a random port on execution but we can also use a fixed port for the tests (as long as it's above 1024). We can also let the user decide on execution by setting a system property.

I hope you'll find this useful.