### PR TITLE
Navigation across qualifier path

### DIFF
--- a/reposilite-frontend/src/mixins.js
+++ b/reposilite-frontend/src/mixins.js
@@ -43,16 +43,21 @@ export default {
       return uri
     },
     parentPath () {
+      const elements = this.splitQualifier()
+      elements.pop()
+
+      const path = this.normalize(elements.join('/'))
+      return path.length === 0 ? '/' : path
+    },
+    splitQualifier () {
       const qualifier = this.getQualifier()
       const elements = qualifier.split('/')
-      elements.pop()
 
       if (qualifier.endsWith('/')) {
         elements.pop()
       }
 
-      const path = this.normalize(elements.join('/'))
-      return path.length === 0 ? '/' : path
+      return elements
     },
     getQualifier () {
       return this.normalize(this.$route.params.qualifier)

--- a/reposilite-frontend/src/views/Index.vue
+++ b/reposilite-frontend/src/views/Index.vue
@@ -29,10 +29,15 @@
                   .flex.justify-between.py-4
                       h1.text-xl
                           | Index of
-                          span.ml-2 {{ this.qualifier }}
-                          router-link(:to="'/dashboard' + this.qualifier")
-                              span.ml-3(:style="'color: ' + this.configuration.accentColor")
-                                  i.fas.fa-feather-alt
+                          span.ml-2
+                              span(v-for="(element, idx) in splitQualifier()")
+                                  router-link(
+                                  :to="splitQualifier().slice(0, idx + 1).join('/')"
+                                  ) {{ element }}
+                                  span /
+                              router-link(:to="'/dashboard' + this.qualifier")
+                                  span.ml-3(:style="'color: ' + this.configuration.accentColor")
+                                      i.fas.fa-feather-alt
                       router-link(
                           v-if="this.qualifier != undefined && this.qualifier.length > 1"
                           :to='parentPath()'

--- a/reposilite-frontend/src/views/Index.vue
+++ b/reposilite-frontend/src/views/Index.vue
@@ -35,9 +35,9 @@
                                   :to="splitQualifier().slice(0, idx + 1).join('/')"
                                   ) {{ element }}
                                   span /
-                              router-link(:to="'/dashboard' + this.qualifier")
-                                  span.ml-3(:style="'color: ' + this.configuration.accentColor")
-                                      i.fas.fa-feather-alt
+                          router-link(:to="'/dashboard' + this.qualifier")
+                              span.ml-3(:style="'color: ' + this.configuration.accentColor")
+                                  i.fas.fa-feather-alt
                       router-link(
                           v-if="this.qualifier != undefined && this.qualifier.length > 1"
                           :to='parentPath()'


### PR DESCRIPTION
I am fairly new to Vue and this is the first time I've looked at Pug, so I'm not sure if there is a better way to achieve this.

This PR allows a user to quickly navigate along the qualifier path.

Ignore no files showing, I was only testing with the frontend and an artificial qualifier. 😅 

![qualifier](https://user-images.githubusercontent.com/42128690/89349516-e9c7f400-d673-11ea-9563-bfc7feaab437.png)
