### PR TITLE
Added system property to set Javalin's requestCacheSize when using debug

### DIFF
--- a/reposilite-backend/src/main/java/org/panda_lang/reposilite/ReposiliteHttpServer.java
+++ b/reposilite-backend/src/main/java/org/panda_lang/reposilite/ReposiliteHttpServer.java
@@ -28,6 +28,7 @@ import org.panda_lang.reposilite.frontend.FrontendController;
 import org.panda_lang.reposilite.repository.DeployController;
 import org.panda_lang.reposilite.repository.LookupApiController;
 import org.panda_lang.reposilite.repository.LookupController;
+import org.panda_lang.reposilite.utils.FilesUtils;
 
 import java.util.Objects;
 
@@ -82,6 +83,8 @@ public final class ReposiliteHttpServer {
         config.enableCorsForAllOrigins();
 
         if (configuration.debugEnabled) {
+            config.requestCacheSize = FilesUtils.displaySizeToBytesCount(System.getProperty("reposilite.requestCacheSize", "8MB"));
+            Reposilite.getLogger().debug("requestCacheSize set to " + config.requestCacheSize + " bytes");
             Reposilite.getLogger().info("Debug enabled");
             config.enableDevLogging();
         }

--- a/reposilite-site/docs/faq.md
+++ b/reposilite-site/docs/faq.md
@@ -15,3 +15,7 @@ It's fine and it does not affect your builds.
 **A:** It is a problem with CDN cache, because Reposilite does not store any files in memory to reduce usage of resources. 
 You should take a look at cache policy of your provider. 
 For instance, if you use Cloudflare, you can set `Cache Level` to `Bypass` through the custom page rules.
+
+**Q:** Artifacts fail to deploy and I see ``Body already consumed, and was too big to cache. Adjust cache size with `config.requestCacheSize = newMaxSize;` `` in the log <br>
+**A:** If you have `debugEnabled`, this can happen with very large artifacts. You can try to tune this by setting the system property `reposilite.requestCacheSize` (defaults to 8MB) to the maximum artifact size. e.g.
+`-Dreposilite.requestCacheSize=20MB`. See using [system properties](./configuration#system-properties) for more information on setting this.


### PR DESCRIPTION
Addresses https://github.com/dzikoysk/reposilite/issues/259 by way of system property.

* Only takes effect when debug is enabled
* Defaults to 8MB
* I've updated the FAQ but I wasn't sure how to test the links, I'm not much of a web dev, but I *think* the links should work