### PR TITLE
GH-268 Add '?' token for HelpCommand

### DIFF
--- a/reposilite-backend/src/main/java/org/panda_lang/reposilite/console/Console.java
+++ b/reposilite-backend/src/main/java/org/panda_lang/reposilite/console/Console.java
@@ -48,6 +48,7 @@ public class Console {
 
         switch (command.toLowerCase()) {
             case "help":
+            case "?":
                 return new HelpCommand().execute(reposilite);
             case "version":
                 return new VersionCommand().execute(reposilite);


### PR DESCRIPTION
This fixes this inconsistency on the Dashboard CLI:
![image](https://user-images.githubusercontent.com/5532443/98813576-22116800-2403-11eb-8d79-c536484fee27.png)
