### PR TITLE
GH-306 Fix disk quota allocation when storing a file

### DIFF
--- a/reposilite-backend/src/main/java/org/panda_lang/reposilite/repository/DiskQuota.java
+++ b/reposilite-backend/src/main/java/org/panda_lang/reposilite/repository/DiskQuota.java
@@ -41,7 +41,7 @@ final class DiskQuota {
     }
 
     public long getUsage() {
-        return usage.longValue();
+        return usage.get();
     }
 
     public static DiskQuota ofPercentage(File workingDirectory, long usage, int percentage) {

--- a/reposilite-backend/src/main/java/org/panda_lang/reposilite/repository/DiskQuota.java
+++ b/reposilite-backend/src/main/java/org/panda_lang/reposilite/repository/DiskQuota.java
@@ -40,6 +40,10 @@ final class DiskQuota {
         return usage.get() < quota.get();
     }
 
+    public long getUsage() {
+        return usage.longValue();
+    }
+
     public static DiskQuota ofPercentage(File workingDirectory, long usage, int percentage) {
         return new DiskQuota(Math.round(workingDirectory.getUsableSpace() * (percentage / 100D)), usage);
     }

--- a/reposilite-backend/src/main/java/org/panda_lang/reposilite/repository/RepositoryStorage.java
+++ b/reposilite-backend/src/main/java/org/panda_lang/reposilite/repository/RepositoryStorage.java
@@ -114,8 +114,8 @@ final class RepositoryStorage {
             Files.move(targetFile.toPath(), lockedFile.toPath(), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
         }
 
-        diskQuota.allocate(lockedFile.length());
         Files.copy(source, lockedFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        diskQuota.allocate(lockedFile.length());
         Files.move(lockedFile.toPath(), targetFile.toPath(), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
 
         task.complete(targetFile);

--- a/reposilite-backend/src/test/groovy/org/panda_lang/reposilite/repository/RepositoryStorageTest.groovy
+++ b/reposilite-backend/src/test/groovy/org/panda_lang/reposilite/repository/RepositoryStorageTest.groovy
@@ -46,7 +46,7 @@ class RepositoryStorageTest {
     }
 
     @Test
-    void 'should add size off written file to the disk quota'() {
+    void 'should add size of written file to the disk quota'() {
         def initialUsage = repositoryStorage.diskQuota.usage
         def string = "test"
         def expectedUsage = initialUsage + string.bytes.length

--- a/reposilite-backend/src/test/groovy/org/panda_lang/reposilite/repository/RepositoryStorageTest.groovy
+++ b/reposilite-backend/src/test/groovy/org/panda_lang/reposilite/repository/RepositoryStorageTest.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020 Ole Ludwig
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.panda_lang.reposilite.repository
+
+import groovy.transform.CompileStatic
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.SynchronousQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+
+@CompileStatic
+class RepositoryStorageTest {
+
+    @TempDir
+    protected File temp
+
+    private RepositoryStorage repositoryStorage
+
+    @BeforeEach
+    void setUp() {
+        ExecutorService ioService = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 1, TimeUnit.SECONDS, new SynchronousQueue<>())
+        ScheduledExecutorService retryService = Executors.newSingleThreadScheduledExecutor()
+        repositoryStorage = new RepositoryStorage(temp, "100%", ioService, retryService)
+    }
+
+    @Test
+    void 'should add size off written file to the disk quota'() {
+        def initialUsage = repositoryStorage.diskQuota.usage
+        def string = "test"
+        def expectedUsage = initialUsage + string.bytes.length
+
+        repositoryStorage.storeFile(new ByteArrayInputStream(string.bytes), temp)
+
+        assertEquals expectedUsage, repositoryStorage.diskQuota.usage
+    }
+}


### PR DESCRIPTION
Fixes the bug, that the disk quota usage isn't updated correctly when uploading a new file. This is caused by reading the size of the locked file before the new file is written to it.
Adds a test to ensure that the disk quota usage is updated correctly.