### PR TITLE
Fix incorrect Content-Type headers in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 
 # Run stage
 FROM openjdk:14-alpine
+RUN apk add --no-cache mailcap
 WORKDIR /app
 RUN mkdir -p /app/data
 VOLUME /app/data


### PR DESCRIPTION
This PR fixes artifacts always being returned with `Content-Type: text/plain` when Reposilite is run from the default image, which resulted in Firefox saving all artifacts with the `.txt` file extension (tested with Firefox 82.0.3 on Windows 10 20H2, and reposilite 2.9.6 from the official image on the server).

Reposilite uses [`java.nio.file.Files.probeContentType(Path)`](https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/nio/file/Files.html#probeContentType(java.nio.file.Path)) when determining the content type of an artifact, and if this returns `null` then it falls back to Javalin's default of `text/plain`. On Linux, OpenJDK [uses the `/etc/mime.types` file to determine file types](https://github.com/openjdk/jdk/blob/jdk-14+0/src/java.base/unix/classes/sun/nio/fs/MimeTypesFileTypeDetector.java), but the `openjdk:14-alpine` image doesn't ship with a `mime.types` file. This PR changes the Dockerfile to install [`mailcap`](https://pkgs.alpinelinux.org/package/edge/main/x86_64/mailcap) which provides a `mime.types` file, allowing file type detection to work properly.

*Note: prior to JDK 9, OpenJDK used to optionally use `libmagic` when available, but this was [removed](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8162624) and is [unlikely to return](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8188228). In JDK 14 (which this image uses), the only implementation of [`FileTypeDetector`](https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/nio/file/spi/FileTypeDetector.html) present by default on Linux is the `MimeTypesFileTypeDetector` mentioned previously.*