### PR TITLE
GH-379 Rewrite DeployService URLs

### DIFF
--- a/reposilite-backend/src/main/java/org/panda_lang/reposilite/Reposilite.java
+++ b/reposilite-backend/src/main/java/org/panda_lang/reposilite/Reposilite.java
@@ -107,7 +107,7 @@ public final class Reposilite {
         this.authenticator = new Authenticator(repositoryService, tokenService);
         this.repositoryAuthenticator = new RepositoryAuthenticator(configuration.rewritePathsEnabled, authenticator, repositoryService);
         this.authService = new AuthService(authenticator);
-        this.deployService = new DeployService(configuration.deployEnabled, authenticator, repositoryService, metadataService);
+        this.deployService = new DeployService(configuration.deployEnabled, configuration.rewritePathsEnabled, authenticator, repositoryService, metadataService);
         this.lookupService = new LookupService(authenticator, repositoryAuthenticator, metadataService, repositoryService, ioService, failureService);
         this.proxyService = new ProxyService(configuration.storeProxied, configuration.rewritePathsEnabled, configuration.proxied, ioService, failureService, repositoryService);
         this.frontend = FrontendProvider.load(configuration);

--- a/reposilite-backend/src/test/groovy/org/panda_lang/reposilite/repository/DeployEndpointTest.groovy
+++ b/reposilite-backend/src/test/groovy/org/panda_lang/reposilite/repository/DeployEndpointTest.groovy
@@ -49,6 +49,7 @@ class DeployEndpointTest extends ReposiliteIntegrationTestSpecification {
     void 'should return 405 and artifact deployment is disabled message' () throws Exception {
         def deployService = new DeployService(
                 false,
+                false,
                 reposilite.getAuthenticator(),
                 reposilite.getRepositoryService(),
                 reposilite.getMetadataService())

--- a/reposilite-backend/src/test/groovy/org/panda_lang/reposilite/repository/DeployServiceTest.groovy
+++ b/reposilite-backend/src/test/groovy/org/panda_lang/reposilite/repository/DeployServiceTest.groovy
@@ -38,6 +38,7 @@ class DeployServiceTest extends ReposiliteTestSpecification {
     void 'should respect disk quota' () {
         def deployService = new DeployService(
                 true,
+                false,
                 super.reposilite.authenticator,
                 new RepositoryService(
                         super.workingDirectory.getAbsolutePath(),


### PR DESCRIPTION
This PR fixes an issue where if you deploy to a rewritten URL it doesn't work, e.g. http://localhost. The deploy does succeed but the files are written to the wrong directory (without the default repository.).

I've tested this and it works fine for us, but obviously, I might have missed something or there might be a better implementation.