### PR TITLE
GH-425 Address ConcurrentModificationException when computing stats.

### DIFF
--- a/reposilite-backend/src/main/java/org/panda_lang/reposilite/stats/StatsEntity.java
+++ b/reposilite-backend/src/main/java/org/panda_lang/reposilite/stats/StatsEntity.java
@@ -18,12 +18,12 @@ package org.panda_lang.reposilite.stats;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ConcurrentSkipListMap;
 
 public final class StatsEntity implements Serializable {
 
-    private final ConcurrentMap<String, Integer> records = new ConcurrentSkipListMap<>();
+    private final ConcurrentMap<String, Integer> records = new ConcurrentHashMap<>();
 
     public void setRecords(Map<String, Integer> records) {
         this.records.putAll(records);

--- a/reposilite-backend/src/main/java/org/panda_lang/reposilite/stats/StatsEntity.java
+++ b/reposilite-backend/src/main/java/org/panda_lang/reposilite/stats/StatsEntity.java
@@ -17,12 +17,13 @@
 package org.panda_lang.reposilite.stats;
 
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 public final class StatsEntity implements Serializable {
 
-    private final Map<String, Integer> records = new HashMap<>(128);
+    private final ConcurrentMap<String, Integer> records = new ConcurrentSkipListMap<>();
 
     public void setRecords(Map<String, Integer> records) {
         this.records.putAll(records);

--- a/reposilite-backend/src/main/java/org/panda_lang/reposilite/stats/StatsService.java
+++ b/reposilite-backend/src/main/java/org/panda_lang/reposilite/stats/StatsService.java
@@ -34,7 +34,7 @@ public final class StatsService {
     }
 
     public void record(String uri) {
-        instanceStats.getRecords().compute(uri, (key, count) -> (count == null) ? 1 : count + 1);
+        instanceStats.getRecords().merge(uri, 1, Integer::sum);
     }
 
     public void saveStats() throws IOException, ExecutionException, InterruptedException {


### PR DESCRIPTION
This PR switches to using `ConcurrentHashMap.merge()`  instead of `HashMap.compute()` when collecting statistics.

I was getting this in the logs when I had our internal repo with no proxies defined as the first repository.

Our builds run with blank repositories, meaning all resources are always resolved, so a lot of traffic.

14:19:41.418 ERROR | /releases/org/hibernate/hibernate-validator/5.3.6.Final/hibernate-validator-5.3.6.Final.pom: java.util.ConcurrentModificationException
        at java.base/java.util.HashMap.compute(HashMap.java:1229)
        at org.panda_lang.reposilite.stats.StatsService.record(StatsService.java:37)
        at org.panda_lang.reposilite.ReposiliteHttpServer.lambda$start$0(ReposiliteHttpServer.java:78)
        at io.javalin.http.JavalinServlet$service$2$1.invoke(JavalinServlet.kt:42)
        at io.javalin.http.JavalinServlet$service$2$1.invoke(JavalinServlet.kt:24)
        at io.javalin.http.JavalinServlet$service$1.invoke(JavalinServlet.kt:129)
        at io.javalin.http.JavalinServlet$service$2.invoke(JavalinServlet.kt:40)
        at io.javalin.http.JavalinServlet.service(JavalinServlet.kt:81)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
        at io.javalin.websocket.JavalinWsServlet.service(JavalinWsServlet.kt:51)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
        at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:791)
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:550)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
        at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1624)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
        at io.javalin.core.JavalinServer$start$wsAndHttpHandler$1.doHandle(JavalinServer.kt:49)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188)
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:501)
        at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1594)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186)
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1350)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
        at org.eclipse.jetty.server.Server.handle(Server.java:516)
        at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:388)
        at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:633)
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:380)
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:279)
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
        at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:336)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:313)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:129)
        at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:383)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:882)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1036)
        at java.base/java.lang.Thread.run(Thread.java:834)