### PR TITLE
GH-516 Document ARM-based Docker image

### DIFF
--- a/reposilite-site/docs/docker.md
+++ b/reposilite-site/docs/docker.md
@@ -75,3 +75,45 @@ $ docker run -it \
 
 As you can see, it is not best solution and as long as possible, 
 you should override default configuration values using the [custom properties](#custom-properties).
+
+### ARM-based systems
+To run Reposilite under docker on an ARM-based system, you'll have to build the image yourself, since the current pipeline doesn't support building multi-arch images, only building for X86 at the moment.
+
+The following Dockerfile should work:
+
+```
+# Build stage
+FROM maven:3.6.3-openjdk-15-slim AS build
+COPY ./ /app/
+RUN mvn -f /app/pom.xml clean package
+
+# Build-time metadata stage
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name="Reposilite" \
+      org.label-schema.description="Lightweight repository management software dedicated for the Maven artifacts" \
+      org.label-schema.url="https://reposilite.com/" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/dzikoysk/reposilite" \
+      org.label-schema.vendor="dzikoysk" \
+      org.label-schema.version=$VERSION \
+      org.label-schema.schema-version="1.0"
+
+# Run stage
+FROM adoptopenjdk:15.0.2_7-jre-hotspot
+WORKDIR /app
+RUN rm -rf /var/lib/apt/lists/* && mkdir -p /app/data
+VOLUME /app/data
+COPY --from=build /app/reposilite-backend/target/reposilite*.jar reposilite.jar
+ENTRYPOINT exec java $JAVA_OPTS -jar reposilite.jar -wd=/app/data $REPOSILITE_OPTS
+```
+
+Save the file locally as `Dockerfile` and build it:
+
+```console
+$ docker build . -t reposilite-arm
+```
+
+To run, just follow the instructions in this page, replacing `dzikoysk/reposilite` by the tag that you have chosen to build the image (`reposilite-arm` in the example).


### PR DESCRIPTION
Adds documentation for ARM-based Docker image. 

Including example working Dockerfile and how to build it.

Not really sure if this should be PR'd to branch 3.0 or master, but from the comments on the issue i guessed it was for the 3.0