### PR TITLE
GH-551 Add 'client_max_body_size' nginx option to docs

### DIFF
--- a/reposilite-site/docs/reverse-proxy.md
+++ b/reposilite-site/docs/reverse-proxy.md
@@ -29,6 +29,8 @@ server {
     access_log /var/log/nginx/reverse-access.log;                                                                                                             
     error_log /var/log/nginx/reverse-error.log;
 
+    client_max_body_size 50m; # maximum artifact upload size
+
     location / {
         proxy_pass http://reposilite;
         proxy_set_header   Host              $host;


### PR DESCRIPTION
Nginx by default has a max body size of [1MB](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size). This PR aims to notify the reader about the maximum.