### PR TITLE
GH-458 Added repository name to maven id

### DIFF
--- a/reposilite-frontend/src/store/maven/repository.js
+++ b/reposilite-frontend/src/store/maven/repository.js
@@ -22,6 +22,7 @@ export default function useRepository() {
 
   const createRepositories = (qualifier) => {
     const repository = computed(() => qualifier.path.split('/')[0])
+    const repoId = id + (qualifier.path ? `-${repository.value}` : '')
     const domain = location.protocol + '//' + location.host + (qualifier.path ? `/${repository.value}` : '/{repository}')
 
     return [
@@ -30,7 +31,7 @@ export default function useRepository() {
         lang: 'xml',
           snippet: `
 <repository>
-  <id>${id}</id>
+  <id>${repoId}</id>
   <name>${title}</name>
   <url>${domain}</url>
 </repository>
@@ -49,7 +50,7 @@ export default function useRepository() {
     {
       name: 'SBT',
         lang: 'scala',
-          snippet: `resolvers += "${id}" at "${domain}"`
+          snippet: `resolvers += "${repoId}" at "${domain}"`
     }
     ]
   }


### PR DESCRIPTION
Added this to my personal build and thought it could be a good addition for the main release.

When on the overview and selecting a repository, e.g. releases, it adds "-releases" behind the repository id. 
Nothing is added when no repository is selected (unlike the domain, where "{repository}" is added instead. I don't think this would be good here, so I just left it as is).

![image](https://user-images.githubusercontent.com/17951467/134189780-f55bddc0-d593-41f9-8b7e-8e7ceebb44db.png)
