### PR TITLE
GH-745 Focus console

### DIFF
--- a/reposilite-frontend/src/components/Console.vue
+++ b/reposilite-frontend/src/components/Console.vue
@@ -35,6 +35,7 @@
       </div>
       <hr class="dark:border-dark-300">
       <input
+        id="consoleInput"
         placeholder="Type command or '?' to get help"
         class="w-full py-2 px-4 rounded-b-lg bg-white dark:bg-gray-900 dark:text-white"
         v-model="command"
@@ -99,6 +100,9 @@ export default {
         })
 
       connect(token)
+      nextTick(() => {
+        setTimeout(() => document.getElementById('consoleInput').focus(), 200)
+      })
     }
 
     watch(


### PR DESCRIPTION
Closes #745 

To be clear before reading further, this PR **does** focus the input _after_ the transition occurs.  
Below is just an explanation on why I deferred to `setTimeout`.

Please let me know if you are aware of a cleaner solution.

-----

When focusing the console immediately (even using `nextTick`), I ended up with a UI glitch like so

![Screenshot from 2021-10-03 14-45-35](https://user-images.githubusercontent.com/42128690/135769221-b930de90-7108-4b79-8bd7-c8c6db0dacba.png)

Setting the timeout was the only way I could get the animation to finish before focusing. It's more or less imperceptible, but I tend to dislike "timing" solutions.

I was unable to hook into the events from the tab library used in a way that didn't cause the above glitch, either.