### PR TITLE
Fix Filter

### DIFF
--- a/reposilite-frontend/fake-api/extensions.js
+++ b/reposilite-frontend/fake-api/extensions.js
@@ -35,7 +35,7 @@ const invalidCredentials = (res) =>
   res.status(401).send('Invalid credentials')
 
 const sendMessage = (connection, message) =>
-  connection.send(new Date().toDateString() + " | " + message)
+  connection.send(`${new Date().toDateString()} ${message}`)
 
 const createFileDetails = (name, contentType, contentLength) =>
   ({ type: 'FILE', name, contentType, contentLength })

--- a/reposilite-frontend/src/store/console/log.js
+++ b/reposilite-frontend/src/store/console/log.js
@@ -25,7 +25,7 @@ const rawLog = reactive([])
 const convert = new Convert()
 
 const getLevel = message =>
-  levelNames.find(level => message.includes(` | ${level.toUpperCase()} | `)) ?? 'Other'
+  levelNames.find(level => message.includes(`${level.toUpperCase()} | `)) ?? 'Other'
 
 const sanitizeMessage = (message) => convert.toHtml(
   message


### PR DESCRIPTION
Fixes #744 

If you look at the screenshot in #744 you'll notice the Java/Kotlin logger only sends a single pipe (`|`).  
This is one solution, another would be to instead insert the required extra pipe in the Java/Kotlin logger (whereas this changes the search to only look for one).

I've also changed the fake API logger to only send a single pipe for closer consistency.