### PR TITLE
GH-743 Add fallback mono font for MacOS

### DIFF
--- a/reposilite-frontend/src/components/Console.vue
+++ b/reposilite-frontend/src/components/Console.vue
@@ -30,7 +30,7 @@
       </div>
     </div>
     <div class="bg-white dark:bg-gray-900 rounded-lg">
-      <div id="console" class="overflow-scroll h-144 px-4">
+      <div id="console" class="overflow-scroll h-144 px-4 whitespace-pre-wrap font-mono text-xs">
         <p v-for="entry in log" :key="entry.id" v-html="entry.message" class="whitespace-nowrap"/>
       </div>
       <hr class="dark:border-dark-300">
@@ -120,11 +120,3 @@ export default {
   }
 }
 </script>
-
-<style>
-#console {
-  white-space: pre-wrap;
-  font-family: 'Consolas', 'monospace';
-  font-size: 12px;
-}
-</style>

--- a/reposilite-frontend/src/components/browser/Card.vue
+++ b/reposilite-frontend/src/components/browser/Card.vue
@@ -62,7 +62,7 @@
           <template v-for="entry in configurations"> 
             <prism-editor 
               v-if="entry.name === selectedTab"
-              class="snippet absolute text-sm" 
+              class="font-mono absolute text-sm"
               v-model="entry.snippet" 
               :highlight="entry.highlighter" 
               readonly
@@ -212,9 +212,6 @@ export default {
   transform: translateX(-60px);
 }
 
-.snippet {
-    font-family: 'Consolas', 'monospace';
-}
 ::-webkit-scrollbar {
   height: 6px;
 }

--- a/reposilite-frontend/windi.config.js
+++ b/reposilite-frontend/windi.config.js
@@ -31,6 +31,9 @@ module.exports = {
       },
       fontSize: {
         xm: ['0.625rem', { lineHeight: '0.75rem' }],
+      },
+      fontFamily: {
+        mono: ['Consolas', 'Monaco', 'monospace']
       }
     }
   }


### PR DESCRIPTION
Added 'Monaco' font as a fallback for 'Consolas' font.
#743 

<img width="596" alt="Screenshot 2021-10-08 at 4 25 19 PM" src="https://user-images.githubusercontent.com/34642968/136545810-c00dd4e0-5dd2-4fbe-b8ea-3c316f86bba2.png">

<img width="1208" alt="Screenshot 2021-10-08 at 4 24 56 PM" src="https://user-images.githubusercontent.com/34642968/136545821-e09b27ae-2d57-4193-8847-3e6d8b687cce.png">
