### PR TITLE
NOISSUE Use prefers-color-scheme if no theme in localStorage

### DIFF
--- a/reposilite-frontend/package-lock.json
+++ b/reposilite-frontend/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "reposilite-frontend",
       "version": "3.0.0-alpha.7",
       "dependencies": {
         "@vueuse/core": "^6.7.3",

--- a/reposilite-frontend/src/store/theme.js
+++ b/reposilite-frontend/src/store/theme.js
@@ -24,9 +24,9 @@ const themeKey = 'dark-theme'
 
 export default function useTheme() {
   const fetchTheme = () => {
-    localStorage.getItem(themeKey) === null ?
-        theme.isDark = window.matchMedia("(prefers-color-scheme: dark)").matches :
-        theme.isDark = (localStorage.getItem(themeKey) === 'true')
+    localStorage.getItem(themeKey) === null
+      ? theme.isDark = window.matchMedia("(prefers-color-scheme: dark)").matches
+      : theme.isDark = (localStorage.getItem(themeKey) === 'true')
   }
 
   const toggleTheme = () => {


### PR DESCRIPTION
Hi, very small PR for something that has bugged me for a bit :)

Currently, the Reposilite frontend will always default to a light mode interface if no theme is chosen. With this patch, if there is no theme chosen, it will first check the [prefers-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) before defaulting to light.

To show that it indeed works as intended, I recorded a video via use of the [Website Dark Mode Switcher](https://github.com/rugk/website-dark-mode-switcher) extension. See that at https://streamable.com/2db5us.