### PR TITLE
GH-956 allow versions to be filtered

### DIFF
--- a/reposilite-backend/src/main/kotlin/com/reposilite/badge/BadgeFacade.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/badge/BadgeFacade.kt
@@ -2,7 +2,7 @@ package com.reposilite.badge
 
 import com.reposilite.badge.api.LatestBadgeRequest
 import com.reposilite.maven.MavenFacade
-import com.reposilite.maven.api.LookupRequest
+import com.reposilite.maven.api.VersionLookupRequest
 import com.reposilite.web.http.ErrorResponse
 import com.reposilite.web.http.errorResponse
 import io.javalin.http.HttpCode.BAD_REQUEST
@@ -37,7 +37,7 @@ class BadgeFacade(
         shortCharacters.sumOf { this.count { char -> char == it } }
 
     fun findLatestBadge(request: LatestBadgeRequest): Result<String, ErrorResponse> =
-        mavenFacade.findLatest(LookupRequest(null, request.repository, request.gav))
+        mavenFacade.findLatest(VersionLookupRequest(null, request.repository, request.gav, request.filter))
             .flatMap { generateSvg(request.name ?: repositoryId.get(), (request.prefix ?: "") + it, request.color ?: colorBlue) }
 
     private fun generateSvg(name: String, value: String, color: String): Result<String, ErrorResponse> {

--- a/reposilite-backend/src/main/kotlin/com/reposilite/badge/api/LatestBadgeRequest.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/badge/api/LatestBadgeRequest.kt
@@ -5,5 +5,6 @@ class LatestBadgeRequest(
     val gav: String,
     val name: String? = null,
     val color: String? = null,
-    val prefix: String? = null
+    val prefix: String? = null,
+    val filter: String? = null
 )

--- a/reposilite-backend/src/main/kotlin/com/reposilite/badge/infrastructure/BadgeEndpoints.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/badge/infrastructure/BadgeEndpoints.kt
@@ -27,7 +27,8 @@ internal class BadgeEndpoints(badgeFacade: BadgeFacade) : ReposiliteRoutes() {
                 gav = requiredParameter("gav"),
                 name = ctx.queryParam("name"),
                 color = ctx.queryParam("color"),
-                prefix = ctx.queryParam("prefix")
+                prefix = ctx.queryParam("prefix"),
+                filter = ctx.queryParam("filter")
             )
             .let { badgeFacade.findLatestBadge(it) }
             .peek { ctx.run {

--- a/reposilite-backend/src/main/kotlin/com/reposilite/maven/MavenFacade.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/maven/MavenFacade.kt
@@ -23,6 +23,7 @@ import com.reposilite.maven.api.DeployRequest
 import com.reposilite.maven.api.LookupRequest
 import com.reposilite.maven.api.METADATA_FILE
 import com.reposilite.maven.api.Metadata
+import com.reposilite.maven.api.VersionLookupRequest
 import com.reposilite.shared.extensions.`when`
 import com.reposilite.shared.fs.DirectoryInfo
 import com.reposilite.shared.fs.DocumentInfo
@@ -112,15 +113,15 @@ class MavenFacade internal constructor(
     fun saveMetadata(repository: String, gav: String, metadata: Metadata): Result<Metadata, ErrorResponse> =
         metadataService.saveMetadata(repository, gav, metadata)
 
-    fun findVersions(lookupRequest: LookupRequest): Result<List<String>, ErrorResponse> =
+    fun findVersions(lookupRequest: VersionLookupRequest): Result<List<String>, ErrorResponse> =
         repositoryService.findRepository(lookupRequest.repository)
             .filter({ repositorySecurityProvider.canAccessResource(lookupRequest.accessToken, it, lookupRequest.gav.toPath())}, { unauthorized() })
-            .flatMap { metadataService.findVersions(it, lookupRequest.gav) }
+            .flatMap { metadataService.findVersions(it, lookupRequest.gav, lookupRequest.filter) }
 
-    fun findLatest(lookupRequest: LookupRequest): Result<String, ErrorResponse> =
+    fun findLatest(lookupRequest: VersionLookupRequest): Result<String, ErrorResponse> =
         repositoryService.findRepository(lookupRequest.repository)
             .filter({ repositorySecurityProvider.canAccessResource(lookupRequest.accessToken, it, lookupRequest.gav.toPath())}, { unauthorized() })
-            .flatMap { metadataService.findLatest(it, lookupRequest.gav) }
+            .flatMap { metadataService.findLatest(it, lookupRequest.gav, lookupRequest.filter) }
 
     fun deployFile(deployRequest: DeployRequest): Result<Unit, ErrorResponse> {
         val repository = repositoryService.getRepository(deployRequest.repository) ?: return notFoundError("Repository not found")

--- a/reposilite-backend/src/main/kotlin/com/reposilite/maven/MetadataService.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/maven/MetadataService.kt
@@ -50,14 +50,15 @@ internal class MetadataService(
             .flatMap { it.putFile(gav.toPath().safeResolve(METADATA_FILE), xml.writeValueAsBytes(metadata).inputStream()) }
             .map { metadata }
 
-    fun findVersions(repository: Repository, gav: String): Result<List<String>, ErrorResponse> =
+    fun findVersions(repository: Repository, gav: String, filter: String?): Result<List<String>, ErrorResponse> =
         repository.getFile(gav.toPath().safeResolve(METADATA_FILE))
             .map { it.use { data -> xml.readValue<Metadata>(data) } }
             .map { it.versioning?.versions ?: emptyList() }
+            .map { if (filter != null) it.filter { version -> version.startsWith(filter) } else it }
             .map { VersionComparator.sortStrings(it) }
 
-    fun findLatest(repository: Repository, gav: String): Result<String, ErrorResponse> =
-        findVersions(repository, gav)
+    fun findLatest(repository: Repository, gav: String, filter: String?): Result<String, ErrorResponse> =
+        findVersions(repository, gav, filter)
             .map { it.last() }
 
 }

--- a/reposilite-backend/src/main/kotlin/com/reposilite/maven/api/VersionLookupRequest.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/maven/api/VersionLookupRequest.kt
@@ -1,0 +1,10 @@
+package com.reposilite.maven.api
+
+import com.reposilite.token.api.AccessToken
+
+data class VersionLookupRequest(
+        val accessToken: AccessToken?,
+        val repository: String,
+        val gav: String,
+        val filter: String?
+)

--- a/reposilite-backend/src/main/kotlin/com/reposilite/maven/infrastructure/MavenApiEndpoints.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/maven/infrastructure/MavenApiEndpoints.kt
@@ -18,6 +18,7 @@ package com.reposilite.maven.infrastructure
 
 import com.reposilite.maven.MavenFacade
 import com.reposilite.maven.api.LookupRequest
+import com.reposilite.maven.api.VersionLookupRequest
 import com.reposilite.shared.fs.FileDetails
 import com.reposilite.web.ContextDsl
 import com.reposilite.web.application.ReposiliteRoute
@@ -82,7 +83,7 @@ internal class MavenApiEndpoints(private val mavenFacade: MavenFacade) : Reposil
     )
     private val findVersions = ReposiliteRoute("/api/maven/versions/{repository}/<gav>", GET) {
         accessed {
-            response = mavenFacade.findVersions(LookupRequest(this, requiredParameter("repository"), requiredParameter("gav")))
+            response = mavenFacade.findVersions(VersionLookupRequest(this, requiredParameter("repository"), requiredParameter("gav"), ctx.queryParam("filter")))
         }
     }
 
@@ -97,7 +98,7 @@ internal class MavenApiEndpoints(private val mavenFacade: MavenFacade) : Reposil
     )
     private val findLatest = ReposiliteRoute("/api/maven/latest/{repository}/<gav>", GET) {
         accessed {
-            response = mavenFacade.findLatest(LookupRequest(this, requiredParameter("repository"), requiredParameter("gav")))
+            response = mavenFacade.findLatest(VersionLookupRequest(this, requiredParameter("repository"), requiredParameter("gav"), ctx.queryParam("filter")))
         }
     }
 

--- a/reposilite-backend/src/test/kotlin/com/reposilite/maven/MavenFacadeTest.kt
+++ b/reposilite-backend/src/test/kotlin/com/reposilite/maven/MavenFacadeTest.kt
@@ -201,7 +201,7 @@ internal class MavenFacadeTest : MavenSpecification() {
         assertOk("1.0.2", response)
         // assertArrayEquals(arrayOf("1.0.0", "1.0.1"), response.get())
     }
-    
+
     @Test
     fun `should find latest version with specific prefix` () {
         // given: an artifact with metadata file
@@ -209,10 +209,10 @@ internal class MavenFacadeTest : MavenSpecification() {
         val artifact = "/gav"
         mavenFacade.saveMetadata(repository, artifact, Metadata(versioning = Versioning(_versions = listOf("2.0.1", "1.0.1", "1.0.2", "1.0.0", "2.0.0", "1.1.0"))))
         val filter = "1.0."
-        
+
         // when: latest version that starts with "1.0." is requested
         val response = mavenFacade.findLatest(VersionLookupRequest(UNAUTHORIZED, repository, artifact, filter))
-        
+
         // then: should return the latest version that starts with "1.0."
         assertOk("1.0.2", response)
     }
@@ -230,7 +230,7 @@ internal class MavenFacadeTest : MavenSpecification() {
         // then: should return all versions of the artifact
         assertOk(listOf("1.0.0", "1.0.1", "1.0.2"), response)
     }
-    
+
     @Test
     fun `should find all versions with specific prefix of the given artifact` () {
         // given: an artifact with metadata file
@@ -238,10 +238,10 @@ internal class MavenFacadeTest : MavenSpecification() {
         val artifact = "/gav"
         mavenFacade.saveMetadata(repository, artifact, Metadata(versioning = Versioning(_versions = listOf("2.0.1", "1.0.1", "1.0.2", "1.0.0", "2.0.0", "1.1.0"))))
         val filter = "1.0."
-        
+
         // when: versions that start with "1.0." of the artifact are requested
         val response = mavenFacade.findVersions(VersionLookupRequest(UNAUTHORIZED, repository, artifact, filter))
-        
+
         // then: should return all versions that start with "1.0." of the artifact
         assertOk(listOf("1.0.0", "1.0.1", "1.0.2"), response)
     }


### PR DESCRIPTION
If you have something that should be implemented differently just write me. It might be also useful to add a filter to show only `alpha`, `beta` or `release` versions, but I think that should be in a second pull request if we want to implement this.