### PR TITLE
GH-1246 Fix for ldap search filter

### DIFF
--- a/reposilite-backend/src/test/kotlin/com/reposilite/auth/LdapAuthenticatorTest.kt
+++ b/reposilite-backend/src/test/kotlin/com/reposilite/auth/LdapAuthenticatorTest.kt
@@ -19,6 +19,7 @@ package com.reposilite.auth
 import com.reposilite.assertCollectionsEquals
 import com.reposilite.auth.api.AuthenticationRequest
 import com.reposilite.auth.specification.AuthenticationSpecification
+import com.reposilite.settings.api.SharedConfiguration.LdapConfiguration
 import com.reposilite.token.AccessTokenType.TEMPORARY
 import com.reposilite.token.api.CreateAccessTokenRequest
 import com.unboundid.ldap.listener.InMemoryDirectoryServer
@@ -50,6 +51,7 @@ internal class LdapAuthenticatorTest : AuthenticationSpecification() {
             val config = InMemoryDirectoryServerConfig(it.baseDn)
             config.addAdditionalBindCredentials(it.searchUserDn, it.searchUserPassword)
             config.addAdditionalBindCredentials("cn=Bella Swan,ou=Maven Users,dc=domain,dc=com", "secret")
+            config.addAdditionalBindCredentials("cn=James Smith,ou=Maven Users,dc=domain,dc=com", "secret2")
             config.listenerConfigs.add(InMemoryListenerConfig.createLDAPConfig(it.hostname, InetAddress.getLoopbackAddress(), it.port, null))
             config.schema = null // remove
 
@@ -64,6 +66,7 @@ internal class LdapAuthenticatorTest : AuthenticationSpecification() {
 
             ldapServer.add("dn: cn=Reposilite,ou=Search Accounts,dc=domain,dc=com", "ou:Search Accounts", "objectClass: person", "memberOf: ou=Search Accounts,dc=domain,dc=com")
             ldapServer.add("dn: cn=Bella Swan,ou=Maven Users,dc=domain,dc=com", "cn:Bella Swan", "ou:Maven Users", "objectClass: person", "memberOf: ou=Maven Users,dc=domain,dc=com")
+            ldapServer.add("dn: cn=James Smith,ou=Maven Users,dc=domain,dc=com", "cn:James Smith", "ou:Maven Users", "objectClass: person", "memberOf: ou=Maven Users,dc=domain,dc=com")
 
         }
 


### PR DESCRIPTION
When configuring reposilite against an LDAP server the connector fails to filter users when there is more than one user in the directory. 

The root cause is in the LdapAuthenticator.kt authenticate function. The first directory search filters users based on the auth request name matched to the userAttribute. There is a second directory search after the user is authenticated where only the userFilter is applied, however the authentication request name is not used nor available to that filter.

Adding the userFilter with userAttribute matched with the authentication request name, as done in the first search resolves the error and makes the ldap connector functional against a realistic directory.
