### PR TITLE
GH-1322 Fix docker nightly builds (add .git directory to build context)

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -27,6 +27,9 @@ jobs:
     name: Docker nightly build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+      - name: Fetch git tags # Required for axion-release-plugin
+        run: git fetch --tags --unshallow
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -40,5 +43,6 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
+          context: .
           push: true
           tags: dzikoysk/reposilite:nightly


### PR DESCRIPTION
The axion-release-plugin couldn't get the current version during the docker nightly build because the `.git` folder was not available. With a manual checkout the `.git` folder should be available now.
Previously the generated jar was `reposilite-0.1.0-SNAPSHOT.jar` (that is the default version) and `COPY --from=build /home/reposilite-build/reposilite-backend/build/libs/reposilite-3*.jar reposilite.jar` didn't work.