### PR TITLE
GH-1330 Internal version for snapshot builds

### DIFF
--- a/reposilite-backend/build.gradle.kts
+++ b/reposilite-backend/build.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.apache.tools.ant.filters.ReplaceTokens
 
 group = "org.panda-lang"
 
@@ -183,6 +184,21 @@ publishing {
             }
         }
     }
+}
+
+tasks.register<Copy>("generateKotlin") {
+    inputs.property("version", version)
+    from("$projectDir/src/template/kotlin")
+    into("$buildDir/generated/kotlin")
+    filter(ReplaceTokens::class, "tokens" to mapOf("version" to version))
+}
+
+tasks.compileKotlin {
+    dependsOn("generateKotlin")
+}
+
+kotlin.sourceSets.main {
+    kotlin.srcDir("$buildDir/generated/kotlin")
 }
 
 kapt {

--- a/reposilite-backend/build.gradle.kts
+++ b/reposilite-backend/build.gradle.kts
@@ -189,7 +189,7 @@ publishing {
 tasks.register<Copy>("generateKotlin") {
     inputs.property("version", version)
     from("$projectDir/src/template/kotlin")
-    into("$buildDir/generated/kotlin")
+    into("$projectDir/src/generated/kotlin")
     filter(ReplaceTokens::class, "tokens" to mapOf("version" to version))
 }
 
@@ -198,7 +198,7 @@ tasks.compileKotlin {
 }
 
 kotlin.sourceSets.main {
-    kotlin.srcDir("$buildDir/generated/kotlin")
+    kotlin.srcDir("$projectDir/src/generated/kotlin")
 }
 
 kapt {

--- a/reposilite-backend/src/generated/kotlin/com/reposilite/ReposiliteProperties.kt
+++ b/reposilite-backend/src/generated/kotlin/com/reposilite/ReposiliteProperties.kt
@@ -1,0 +1,3 @@
+package com.reposilite
+
+const val VERSION = "3.0.0-alpha.26-SNAPSHOT"

--- a/reposilite-backend/src/main/kotlin/com/reposilite/Reposilite.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/Reposilite.kt
@@ -34,8 +34,6 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.atomic.AtomicBoolean
 
-const val VERSION = "3.0.0-alpha.25"
-
 class Reposilite(
     val journalist: ReposiliteJournalist,
     val parameters: ReposiliteParameters,

--- a/reposilite-backend/src/main/kotlin/com/reposilite/plugin/api/Plugin.java
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/plugin/api/Plugin.java
@@ -16,7 +16,7 @@
 
 package com.reposilite.plugin.api;
 
-import com.reposilite.ReposiliteKt;
+import com.reposilite.ReposilitePropertiesKt;
 import com.reposilite.configuration.shared.SharedSettings;
 
 import java.lang.annotation.ElementType;
@@ -38,9 +38,9 @@ public @interface Plugin {
 
     /**
      * @return version of plugin, by default it is same as the current Reposilite version
-     * @see com.reposilite.ReposiliteKt#VERSION
+     * @see com.reposilite.ReposilitePropertiesKt#VERSION
      */
-    String version() default ReposiliteKt.VERSION;
+    String version() default ReposilitePropertiesKt.VERSION;
 
     /**
      * @return array of plugins required to launch before this one

--- a/reposilite-backend/src/template/kotlin/com/reposilite/ReposiliteProperties.kt
+++ b/reposilite-backend/src/template/kotlin/com/reposilite/ReposiliteProperties.kt
@@ -1,0 +1,3 @@
+package com.reposilite
+
+const val VERSION = "@version@"


### PR DESCRIPTION
The contents of `src/template/kotlin` are copied to `src/generated/kotlin` and `@version@` gets replaced with the version.
I think `src/generated/kotlin` is better than `build/generated/kotlin` because otherwise the ide would show an error before the first compilation and after each `./gradlew clean`.