### PR TITLE
Fix wrong plugin description

### DIFF
--- a/reposilite-site/data/plugins/migration.md
+++ b/reposilite-site/data/plugins/migration.md
@@ -1,7 +1,7 @@
 ---
 id: migration
 title: Migration
-description: Mount Swagger UI for your Reposilite instance
+description: Migrate your tokens from 2.x to 3.x
 official: true
 repository: dzikoysk/reposilite
 authors: [ 'dzikoysk' ]


### PR DESCRIPTION
While browsing the reposilite website, I noticed that the plugin description for the Migration plugin was copied from the Swagger UI plugin. This is of course not intended, as they do completely different things. This PR aims to fix this issue.