### PR TITLE
GH-1397 Explain the IP to use for Nginx reverse proxy

### DIFF
--- a/reposilite-site/data/guides/integrations/nginx.md
+++ b/reposilite-site/data/guides/integrations/nginx.md
@@ -12,8 +12,9 @@ map $http_upgrade $connection_upgrade {
     '' close;
 }
 
-# Reposilite IP and port
+# load balancing pool for Reposilite
 upstream reposilite {
+    # Reposilite IP and port, see below for explanation
     server domain.com:8081;
 }
 
@@ -27,7 +28,7 @@ server {
     client_max_body_size 50m; # maximum artifact upload size
 
     location / {
-        proxy_pass http://reposilite;
+        proxy_pass http://reposilite; # references the before specified upstream
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;
         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
@@ -38,6 +39,18 @@ server {
     }
 }
 ```
+
+Depending on your inital setup of Reposilite the IP address to use will vary.
+
+If you want to reference a Reposilite instance running on a different machine, use it's IP address
+or a domain name pointing to it. If Reposilite runs on the same machine (possibly in a Docker
+container), use `localhost`. If you are using Docker compose to provision both Reposilite and Nginx
+you can simply reference the Reposilite instance via it's service name directly and do not need to
+expose any port of the Reposilite container (see [Networking in Compose](https://docs.docker.com/compose/networking/)).
+
+Also, don't forget to change the port according to your Reposilite startup parameters.
+
+#### Custom base path
 
 To use custom base path (e.g. `domain.com/reposilite`), modify the configuration just like this:
 

--- a/reposilite-site/data/guides/integrations/nginx.md
+++ b/reposilite-site/data/guides/integrations/nginx.md
@@ -12,7 +12,7 @@ map $http_upgrade $connection_upgrade {
     '' close;
 }
 
-# load balancing pool for Reposilite
+# Load balancing pool for Reposilite
 upstream reposilite {
     # Reposilite IP and port, see below for explanation
     server domain.com:8081;
@@ -25,10 +25,10 @@ server {
     access_log /var/log/nginx/reverse-access.log;
     error_log /var/log/nginx/reverse-error.log;
 
-    client_max_body_size 50m; # maximum artifact upload size
+    client_max_body_size 50m; # maximum allowed artifact upload size
 
     location / {
-        proxy_pass http://reposilite; # references the before specified upstream
+        proxy_pass http://reposilite; # the name of Reposilite's upstream specified above
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;
         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
@@ -40,12 +40,14 @@ server {
 }
 ```
 
-Depending on your inital setup of Reposilite the IP address to use will vary.
+Depending on your inital setup of Reposilite, the IP address to use will vary.
 
-If you want to reference a Reposilite instance running on a different machine, use it's IP address
-or a domain name pointing to it. If Reposilite runs on the same machine (possibly in a Docker
-container), use `localhost`. If you are using Docker compose to provision both Reposilite and Nginx
-you can simply reference the Reposilite instance via it's service name directly and do not need to
+* If you want to reference a Reposilite instance running on a different machine, use its IP address
+or a domain name pointing to it. 
+* If Reposilite runs on the same machine (possibly in a Docker
+container), use `localhost`. 
+* If you are using Docker Compose to combine both, Reposilite and Nginx, 
+you can simply reference the Reposilite instance via its service name directly and you do not need to
 expose any port of the Reposilite container (see [Networking in Compose](https://docs.docker.com/compose/networking/)).
 
 Also, don't forget to change the port according to your Reposilite startup parameters.


### PR DESCRIPTION
Added some notes on what IP address to use when using Nginx as reverse proxy in different scenarios as we previously had some people getting confused about it.