### PR TITLE
Webhook Plugin (v2)

### DIFF
--- a/reposilite-plugins/webhook-plugin/build.gradle.kts
+++ b/reposilite-plugins/webhook-plugin/build.gradle.kts
@@ -1,0 +1,22 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
+group = "com.reposilite.plugins"
+
+plugins {
+    id("com.github.johnrengelman.shadow") version "7.1.2"
+    kotlin("jvm")
+}
+
+application {
+    mainClass.set("com.reposilite.plugin.webhook.WebhookPluginKt")
+}
+
+dependencies {
+    compileOnly(project(":reposilite-backend"))
+}
+
+tasks.withType<ShadowJar> {
+    archiveFileName.set("webhook-plugin.jar")
+    destinationDirectory.set(file("$rootDir/reposilite-backend/src/test/workspace/plugins"))
+    mergeServiceFiles()
+}

--- a/reposilite-plugins/webhook-plugin/src/main/kotlin/com/reposilite/plugin/webhook/WebhookPlugin.kt
+++ b/reposilite-plugins/webhook-plugin/src/main/kotlin/com/reposilite/plugin/webhook/WebhookPlugin.kt
@@ -1,0 +1,7 @@
+package com.reposilite.plugin.webhook
+
+import com.reposilite.plugin.api.Plugin
+
+@Plugin(name = "webhook")
+class WebhookPlugin {
+}

--- a/reposilite-plugins/webhook-plugin/src/main/resources/META-INF/services/com.reposilite.plugin.api.ReposilitePlugin
+++ b/reposilite-plugins/webhook-plugin/src/main/resources/META-INF/services/com.reposilite.plugin.api.ReposilitePlugin
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2022 dzikoysk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+com.reposilite.plugin.webhook.WebhookPlugin

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,5 +23,6 @@ include(
     "reposilite-plugins:groovy-plugin",
     "reposilite-plugins:javadoc-plugin",
     "reposilite-plugins:migration-plugin",
-    "reposilite-plugins:swagger-plugin"
+    "reposilite-plugins:swagger-plugin",
+    "reposilite-plugins:webhook-plugin"
 )


### PR DESCRIPTION
Adds the ability to send a webhook message to a service (Discord, Slack, etc.) on an event such as a new version being pushed to the repo.

Related issues: #844 