### PR TITLE
GH-1423 Add snapshot support to javadoc-plugin

### DIFF
--- a/reposilite-plugins/javadoc-plugin/src/main/kotlin/com/reposilite/plugin/javadoc/JavadocFacade.kt
+++ b/reposilite-plugins/javadoc-plugin/src/main/kotlin/com/reposilite/plugin/javadoc/JavadocFacade.kt
@@ -107,7 +107,17 @@ class JavadocFacade internal constructor(
 
                 if (elements.size >= 2) {
                     val name = elements[elements.size - 2]
-                    val version = elements[elements.size - 1]
+                    var version = elements[elements.size - 1]
+
+                    if (version.contains("-SNAPSHOT")) {
+                        val metadataResult = mavenFacade.findMetadata(repository, rootGav)
+                        val snapshot = if (metadataResult.isOk) metadataResult.get().versioning?.snapshot else null
+
+                        if (snapshot?.timestamp != null && snapshot.buildNumber != null) {
+                            version = "${version.replace("-SNAPSHOT", "")}-${snapshot.timestamp}-${snapshot.buildNumber}"
+                        }
+                    }
+
                     rootGav.resolve("${name}-${version}-javadoc.jar")
                 }
                 else null


### PR DESCRIPTION
Adds the ability to use the javadoc-plugin with snapshot versions.
See #1423 for more information

I am not very familiar with the code base so if there is a better way of doing this, please let me know so I can improve.