### PR TITLE
GH-1455 Guide Improvement. Adding <settings> wrapper for m2 settings

### DIFF
--- a/reposilite-site/data/guides/features/deployment.md
+++ b/reposilite-site/data/guides/features/deployment.md
@@ -22,14 +22,16 @@ Let's say we want to deploy artifact to the `releases` repository:
 To use generated token, add a new server in your [~/.m2/settings.xml](https://maven.apache.org/settings.html):
 
 ```xml
-<servers>
-  <server>
-    <!-- Id has to match the id provided in pom.xml -->
-    <id>my-domain-repository</id>
-    <username>{token}</username>
-    <password>{secret}</password>
-  </server>
-</servers>
+<settings>
+  <servers>
+    <server>
+      <!-- Id has to match the id provided in pom.xml -->
+      <id>my-domain-repository</id>
+      <username>{token}</username>
+      <password>{secret}</password>
+    </server>
+  </servers>
+</settings>
 ```
 
 If you've configured everything correctly, you should be able to deploy artifact using the following command:


### PR DESCRIPTION
For `~/m2/settings.xml`, configurations should be placed inside `settings` tag. If it's not there, maven deploy plugin fails in some cases with a misleading error  `401 Unauthorized`.

For reference, please see https://github.com/dzikoysk/reposilite/issues/1455#issuecomment-1175224848