### PR TITLE
GH-1467 Make the plugin directory configurable

### DIFF
--- a/reposilite-backend/src/main/kotlin/com/reposilite/ReposiliteFactory.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/ReposiliteFactory.kt
@@ -52,6 +52,7 @@ object ReposiliteFactory {
         journalist.logger.info("Platform: ${System.getProperty("java.version")} (${System.getProperty("os.name")} :: ${System.getProperty("os.arch")})")
         journalist.logger.info("Running as: ${System.getProperty("user.name")}")
         journalist.logger.info("Working directory: ${parameters.workingDirectory.toAbsolutePath()}")
+        journalist.logger.info("Plugin directory: ${parameters.pluginDirectory.toAbsolutePath()}")
         journalist.logger.info("Configuration: ${parameters.localConfigurationPath.absolutePathString()}")
         journalist.logger.info("Threads: ${localConfiguration.webThreadPool.get()} WEB / ${localConfiguration.ioThreadPool.get()} IO / ${localConfiguration.databaseThreadPool.get()} DB")
         if (parameters.testEnv) journalist.logger.info("Test environment enabled")
@@ -70,7 +71,7 @@ object ReposiliteFactory {
         journalist.logger.info("")
         journalist.logger.info("--- Loading plugins:")
 
-        val pluginLoader = PluginLoader(parameters.workingDirectory.resolve("plugins"), reposilite.extensions)
+        val pluginLoader = PluginLoader(parameters.pluginDirectory, reposilite.extensions)
         pluginLoader.extensions.registerFacade(reposilite)
         pluginLoader.loadPluginsByServiceFiles()
         pluginLoader.initialize()

--- a/reposilite-backend/src/main/kotlin/com/reposilite/ReposiliteParameters.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/ReposiliteParameters.kt
@@ -41,6 +41,10 @@ class ReposiliteParameters : Runnable {
     var workingDirectoryName = ""
     lateinit var workingDirectory: Path
 
+    @Option(names = ["--plugin-directory", "-pd"], description = ["Set custom plugin directory"])
+    var pluginDirectoryName: String? = null
+    lateinit var pluginDirectory: Path
+
     @Option(names = ["--generate-configuration", "-gc"], description = ["" +
         "Generate default template of the configuration file. Supported templates:",
         "configuration.cdn - Local configuration file",
@@ -81,6 +85,7 @@ class ReposiliteParameters : Runnable {
 
     override fun run() {
         this.workingDirectory = Paths.get(workingDirectoryName)
+        this.pluginDirectory = pluginDirectoryName?.let { Paths.get(it) } ?: workingDirectory.resolve("plugins")
 
         this.localConfigurationPath = localConfigurationFile.let { workingDirectory.resolve(it.ifEmpty { LOCAL_CONFIGURATION_FILE }) }
         this.sharedConfigurationPath = sharedConfigurationFile?.let { workingDirectory.resolve(it.ifEmpty { SHARED_CONFIGURATION_FILE }) }


### PR DESCRIPTION
Since plugins are technically a part of the code, not the configuration, it should be possible to separate them from the workdir.