### PR TITLE
GH-1557 Update and improve Actions workflows

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,6 +31,9 @@ jobs:
         java-version: "${{ matrix.java-version }}"
         distribution: "adopt"
 
+    - name: "Grant execute permission for gradlew"
+      run: chmod +x gradlew
+
     - name: "Gradle build"
       uses: gradle/gradle-build-action@v2
       with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,35 +1,43 @@
-name: Reposilite CI
+# GitHub Actions workflow to automatically build Reposilite.
+name: "Gradle"
 
 on:
   push:
-    branches: [ master, main, "3.0" ]
+    branches: [ "main", "3.0" ]
   pull_request:
-    branches: [ master, main, "3.0" ]
+    branches: [ "main", "3.0" ]
 
 jobs:
   build:
-    name: "Build with JDK${{ matrix.jdk }}"
+    name: "Build with Java ${{ matrix.java-version }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:
         # Use 11 LTS releases and the latest one
-        jdk: [ 11, 18 ]
+        java-version: [ 11, 18 ]
     steps:
-    - uses: actions/checkout@v3
-    - name: Fetch git tags # Required for axion-release-plugin
+    - name: "Checkout repository"
+      uses: actions/checkout@v3
+
+    - name: "Fetch git tags" # Required for axion-release-plugin
       run: git fetch --tags --unshallow
-    - name: Verify gradle wrapper
+
+    - name: "Validate gradle wrapper"
       uses: gradle/wrapper-validation-action@v1
-    - name: Set up JDK
-      uses: actions/setup-java@v1
+
+    - name: "Set up Java ${{ matrix.java-version }}"
+      uses: actions/setup-java@v3
       with:
-        java-version: ${{ matrix.jdk }}
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-    - name: Build with Gradle
-      run: ./gradlew :reposilite-backend:testCoverage
-    - name: Upload coverage to Codecov
+        java-version: "${{ matrix.java-version }}"
+        distribution: "adopt"
+
+    - name: "Gradle build"
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: ":reposilite-backend:testCoverage"
+
+    - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v2
       with:
-        files: ./reposilite-backend/build/reports/jacoco/reposilite-backend-report.xml
+        files: "./reposilite-backend/build/reports/jacoco/reposilite-backend-report.xml"
         fail_ci_if_error: false

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,5 +1,5 @@
-# GitHub Actions workflow to automatically build Reposilite.
-name: "Gradle"
+# GitHub Actions workflow to automatically build and test Reposilite.
+name: "Reposilite CI"
 
 on:
   push:
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # Use 11 LTS releases and the latest one
-        java-version: [ 11, 18 ]
+        jdk: [ 11, 18 ]
     steps:
     - name: "Checkout repository"
       uses: actions/checkout@v3
@@ -25,10 +25,10 @@ jobs:
     - name: "Validate gradle wrapper"
       uses: gradle/wrapper-validation-action@v1
 
-    - name: "Set up Java ${{ matrix.java-version }}"
+    - name: "Set up JDK ${{ matrix.jdk }}"
       uses: actions/setup-java@v3
       with:
-        java-version: "${{ matrix.java-version }}"
+        java-version: "${{ matrix.jdk }}"
         distribution: "adopt"
 
     - name: "Grant execute permission for gradlew"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,12 +9,12 @@ on:
 
 jobs:
   build:
-    name: "Build with Java ${{ matrix.java-version }}"
+    name: "Build with JDK ${{ matrix.java-version }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:
         # Use 11 LTS releases and the latest one
-        jdk: [ 11, 18 ]
+        java-version: [ 11, 18 ]
     steps:
     - name: "Checkout repository"
       uses: actions/checkout@v3
@@ -25,10 +25,10 @@ jobs:
     - name: "Validate gradle wrapper"
       uses: gradle/wrapper-validation-action@v1
 
-    - name: "Set up JDK ${{ matrix.jdk }}"
+    - name: "Set up Java ${{ matrix.java-version }}"
       uses: actions/setup-java@v3
       with:
-        java-version: "${{ matrix.jdk }}"
+        java-version: "${{ matrix.java-version }}"
         distribution: "adopt"
 
     - name: "Grant execute permission for gradlew"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,77 +1,112 @@
-name: Publish release builds
-
+# GitHub Actions workflow to publish new releases.
+name: "Release"
 on: workflow_dispatch
+
+env:
+  JAVA_VERSION: 18
 
 jobs:
   release:
+    name: "Release"
     runs-on: ubuntu-latest
     permissions:
       contents: write
     outputs:
-      version: ${{ steps.version.outputs.version }}
+      version: "${{ steps.version.outputs.version }}"
     steps:
-      - uses: actions/checkout@v3
-      - name: Fetch git tags # Required for axion-release-plugin
+      - name: "Checkout repository"
+        uses: actions/checkout@v3
+
+      - name: "Fetch git tags" # Required for axion-release-plugin
         run: git fetch --tags --unshallow
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+
+      - name: "Set up Java ${{ env.JAVA_VERSION }}"
+        uses: actions/setup-java@v3
         with:
-          java-version: 18
-      - name: Grant execute permission for gradlew
+          java-version: "${{ env.JAVA_VERSION }}"
+          distribution: "adopt"
+
+      - name: "Grant execute permission for gradlew"
         run: chmod +x gradlew
-      - name: Release new version
+
+      - name: "Release new version"
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           ./gradlew release
-      - name: Get current version
+
+      - name: "Get current version"
         id: version
         run: echo "::set-output name=version::$(./gradlew -q -Prelease.quiet cV)"
 
   gradle:
+    name: "Gradle Publish"
     runs-on: ubuntu-latest
     needs: [ release ]
     steps:
-      - uses: actions/checkout@v3
+      - name: "Checkout repository"
+        uses: actions/checkout@v3
         with:
-          ref: refs/tags/${{ needs.release.outputs.version }}
-      - name: Fetch git tags # Required for axion-release-plugin
+          ref: "refs/tags/${{ needs.release.outputs.version }}"
+
+      - name: "Fetch git tags" # Required for axion-release-plugin
         run: git fetch --tags --unshallow
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+
+      - name: "Set up Java ${{ env.JAVA_VERSION }}"
+        uses: actions/setup-java@v3
         with:
-          java-version: 18
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-      - name: Publish with Gradle
-        run: ./gradlew shadowJar publish
+          java-version: "${{ env.JAVA_VERSION }}"
+          distribution: "adopt"
+
+      - name: "Gradle publish"
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: "shadowJar publish"
         env:
           MAVEN_NAME: ${{ secrets.MAVEN_NAME }}
           MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
 
   docker:
+    name: "Docker Push"
     runs-on: ubuntu-latest
     needs: [ release ]
     steps:
-      - uses: actions/checkout@v3
+      - name: "Checkout repository"
+        uses: actions/checkout@v3
         with:
-          ref: refs/tags/${{ needs.release.outputs.version }}
-      - name: Fetch git tags # Required for axion-release-plugin
+          ref: "refs/tags/${{ needs.release.outputs.version }}"
+
+      - name: "Fetch git tags" # Required for axion-release-plugin
         run: git fetch --tags --unshallow
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+
+      - name: "Set up QEMU"
+        uses: docker/setup-qemu-action@v2
+
+      - name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v2
+
+      - name: "Login to DockerHub"
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push
+
+      - name: "Login to GitHub Container Registry"
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Build and push"
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
+          platforms: "linux/amd64,linux/arm64"
           push: true
-          tags: dzikoysk/reposilite:${{ needs.release.outputs.version }},dzikoysk/reposilite:latest
-          platforms: linux/amd64,linux/arm64
+          tags: |
+            dzikoysk/reposilite:latest
+            dzikoysk/reposilite:${{ needs.release.outputs.version }}
+            ghcr.io/dzikoysk/reposilite:latest
+            ghcr.io/dzikoysk/reposilite:${{ needs.release.outputs.version }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,13 +1,13 @@
 # GitHub Actions workflow to publish new releases.
-name: "Release"
+name: "Publish releases"
 on: workflow_dispatch
 
 env:
   JAVA_VERSION: 18
 
 jobs:
-  release:
-    name: "Release"
+  github:
+    name: "GitHub"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -39,15 +39,15 @@ jobs:
         id: version
         run: echo "::set-output name=version::$(./gradlew -q -Prelease.quiet cV)"
 
-  gradle:
-    name: "Gradle Publish"
+  maven:
+    name: "Maven"
     runs-on: ubuntu-latest
-    needs: [ release ]
+    needs: [ github ]
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
         with:
-          ref: "refs/tags/${{ needs.release.outputs.version }}"
+          ref: "refs/tags/${{ needs.github.outputs.version }}"
 
       - name: "Fetch git tags" # Required for axion-release-plugin
         run: git fetch --tags --unshallow
@@ -70,14 +70,14 @@ jobs:
           MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
 
   docker:
-    name: "Docker Push"
+    name: "Docker"
     runs-on: ubuntu-latest
-    needs: [ release ]
+    needs: [ github ]
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
         with:
-          ref: "refs/tags/${{ needs.release.outputs.version }}"
+          ref: "refs/tags/${{ needs.github.outputs.version }}"
 
       - name: "Fetch git tags" # Required for axion-release-plugin
         run: git fetch --tags --unshallow
@@ -110,6 +110,6 @@ jobs:
           push: true
           tags: |
             dzikoysk/reposilite:latest
-            dzikoysk/reposilite:${{ needs.release.outputs.version }}
+            dzikoysk/reposilite:${{ needs.github.outputs.version }}
             ghcr.io/dzikoysk/reposilite:latest
-            ghcr.io/dzikoysk/reposilite:${{ needs.release.outputs.version }}
+            ghcr.io/dzikoysk/reposilite:${{ needs.github.outputs.version }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -58,6 +58,9 @@ jobs:
           java-version: "${{ env.JAVA_VERSION }}"
           distribution: "adopt"
 
+      - name: "Grant execute permission for gradlew"
+        run: chmod +x gradlew
+
       - name: "Gradle publish"
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,5 +1,5 @@
 # GitHub Actions workflow to automatically publish snapshot builds.
-name: "Snapshot"
+name: "Publish snapshots"
 on:
   push:
     branches: [ "main" ]
@@ -8,8 +8,8 @@ env:
   JAVA_VERSION: 18
 
 jobs:
-  publish:
-    name: "Publish"
+  maven:
+    name: "Maven"
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository"
@@ -36,7 +36,7 @@ jobs:
           MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
 
   docker:
-    name: "Docker publish nightly"
+    name: "Docker"
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -24,6 +24,9 @@ jobs:
           java-version: "${{ env.JAVA_VERSION }}"
           distribution: "adopt"
 
+      - name: "Grant execute permission for gradlew"
+        run: chmod +x gradlew
+
       - name: "Gradle publish"
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,48 +1,72 @@
-name: Snapshot builds
-
+# GitHub Actions workflow to automatically publish snapshot builds.
+name: "Snapshot"
 on:
   push:
-    branches: [ 'main' ]
+    branches: [ "main" ]
+
+env:
+  JAVA_VERSION: 18
 
 jobs:
   publish:
-    name: Publish snapshot
+    name: "Publish"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Fetch git tags # Required for axion-release-plugin
+      - name: "Checkout repository"
+        uses: actions/checkout@v3
+
+      - name: "Fetch git tags" # Required for axion-release-plugin
         run: git fetch --tags --unshallow
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+
+      - name: "Set up Java ${{ env.JAVA_VERSION }}"
+        uses: actions/setup-java@v3
         with:
-          java-version: 18
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-      - name: Publish with Gradle
-        run: ./gradlew shadowJar publish
+          java-version: "${{ env.JAVA_VERSION }}"
+          distribution: "adopt"
+
+      - name: "Gradle publish"
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: "shadowJar publish"
         env:
           MAVEN_NAME: ${{ secrets.MAVEN_NAME }}
           MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
+
   docker:
-    name: Docker nightly build
+    name: "Docker publish nightly"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Fetch git tags # Required for axion-release-plugin
+      - name: "Checkout repository"
+        uses: actions/checkout@v3
+
+      - name: "Fetch Git tags" # Required for axion-release-plugin
         run: git fetch --tags --unshallow
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+
+      - name: "Set up QEMU"
+        uses: docker/setup-qemu-action@v2
+
+      - name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v2
+
+      - name: "Login to DockerHub"
+        uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push
+          username: "${{ secrets.DOCKERHUB_USERNAME }}"
+          password: "${{ secrets.DOCKERHUB_TOKEN }}"
+
+      - name: "Login to GitHub Container Registry"
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: "${{ github.repository_owner }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: "Build and push"
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: true
-          tags: dzikoysk/reposilite:nightly
+          tags: |
+            dzikoysk/reposilite:nightly
+            ghcr.io/dzikoysk/reposilite:nightly


### PR DESCRIPTION
This pull request aims to improve the GitHub Actions workflows.
To do this, this pull request:
 - Updates all Actions to the latest versions.
 - Uses the `gradle-build-action` to build with Gradle. (1)
 - Adds steps to push Reposilite to GHCR.
 - Attempt to improve readability.

1: The [`gradle-build-action`](https://github.com/gradle/gradle-build-action/) has several advantages:
 - Easier to use,
 - More sophisticated and more efficient caching,
 - Detailed reporting of cache usage,

Note: It's kind of hard to test Actions workflows, so I am not sure if this is going to work on
the first attempt. I apologise in advance if this breaks.
