### PR TITLE
Set default S3 region to prevent crashes

### DIFF
--- a/reposilite-backend/src/main/kotlin/com/reposilite/storage/s3/S3StorageProviderFactory.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/storage/s3/S3StorageProviderFactory.kt
@@ -27,6 +27,8 @@ class S3StorageProviderFactory : StorageProviderFactory<S3StorageProvider, S3Sto
 
         if (settings.region.isNotEmpty()) {
             client.region(Region.of(settings.region))
+        } else {
+            client.region(Region.of("reposilite"))
         }
 
         if (settings.endpoint.isNotEmpty()) {


### PR DESCRIPTION
Fixes #1666 by always setting a region on the S3 client.

I've not been able to test this locally (even with the docker-compose config), and have never written Kotlin, so I am unsure whether this works. If another solution is preferred feel free to close this PR.