### PR TITLE
GH-1692 Fix broken javadoc latest redirect

### DIFF
--- a/reposilite-backend/src/main/kotlin/com/reposilite/javadocs/JavadocFacade.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/javadocs/JavadocFacade.kt
@@ -110,7 +110,7 @@ class JavadocFacade internal constructor(
             ?.let { request.gav.locationBeforeLast("/latest") }
             ?.let { gavWithoutVersion -> VersionLookupRequest(request.accessToken, request.repository, gavWithoutVersion) }
             ?.let { mavenFacade.findLatestVersion(it) }
-            ?.map { request.gav.replace(LATEST_PATTERN, "%s".format(it.version)) }
+            ?.map { request.gav.replace(LATEST_PATTERN, "/%s".format(it.version)) }
             ?.orNull()
             ?: request.gav
 


### PR DESCRIPTION
The /javadoc/ handler /latest logic didn't work because it removed the leading / from the URL when redirecting.

A URL like:
`http://0.0.0.0:8080/javadoc/everything/com/bergerkiller/bukkit/BKCommonLib/latest`
Turnt into:
`http://0.0.0.0:8080/javadoc/everything/com/bergerkiller/bukkit/BKCommonLib1.19.3-SNAPSHOT`
Instead of:
`http://0.0.0.0:8080/javadoc/everything/com/bergerkiller/bukkit/BKCommonLib/1.19.3-SNAPSHOT`