### PR TITLE
GH-1726 Bugfix for version comparator + tests

### DIFF
--- a/reposilite-backend/src/main/kotlin/com/reposilite/storage/Comparators.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/storage/Comparators.kt
@@ -71,7 +71,7 @@ open class VersionComparator<T>(
                 }
                 // Prioritize digits over strings
                 else if (baseIsDigit || toFragment.isDigit()) {
-                    if (baseIsDigit) -1 else 1
+                    if (baseIsDigit) 1 else -1
                 }
                 // Compare strings
                 else {

--- a/reposilite-backend/src/test/kotlin/com/reposilite/shared/fs/FileComparatorsTest.kt
+++ b/reposilite-backend/src/test/kotlin/com/reposilite/shared/fs/FileComparatorsTest.kt
@@ -42,14 +42,14 @@ internal class FileComparatorsTest : FileComparatorsSpecification() {
         // then: sorted list matches expected rules
         assertEquals(
             listOf(
-                directory("1.0.1"),
-                directory("1.0.2"),
                 directory("Reposilite"),
                 directory("Zeolite"),
-                file("1.0.2"),
-                file("1.0.3"),
+                directory("1.0.1"),
+                directory("1.0.2"),
                 file("Apposite"),
                 file("Lolita"),
+                file("1.0.2"),
+                file("1.0.3"),
             ),
             sortedResult
         )

--- a/reposilite-backend/src/test/kotlin/com/reposilite/storage/VersionComparatorTest.kt
+++ b/reposilite-backend/src/test/kotlin/com/reposilite/storage/VersionComparatorTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2023 dzikoysk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reposilite.storage
+
+import com.reposilite.storage.specification.VersionComparatorSpecification
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class VersionComparatorTest : VersionComparatorSpecification() {
+
+    @Test
+    fun `should sort semantic versions in ascending order`() {
+        // given: an unordered list of versions
+        val versions = listOf(
+            "1.2.3-SNAPSHOT",
+            "1.2",
+            "0.5",
+            "1.0",
+            "1.1.5-SNAPSHOT",
+            "word",
+            "1.1.4",
+            "1.1",
+            "1.1.4-SNAPSHOT"
+        )
+
+        // when: an unordered list is sorted
+        val sortedResult = versions.sortedWith(versionComparator)
+
+        // then: sorted list matches expected rules
+        assertEquals(
+            listOf(
+                "word",
+                "0.5",
+                "1.0",
+                "1.1",
+                "1.1.4-SNAPSHOT",
+                "1.1.4",
+                "1.1.5-SNAPSHOT",
+                "1.2",
+                "1.2.3-SNAPSHOT"
+            ),
+            sortedResult
+        )
+    }
+
+    @Test
+    fun `should sort double-digit style minor versions in ascending order`() {
+        // given: an unordered list of versions
+        val versions = listOf(
+            "0.12",
+            "1.00",
+            "1.05",
+            "1.12-SNAPSHOT",
+            "1.12",
+            "word",
+            "1.20",
+            "1.20.5-SNAPSHOT"
+        )
+
+        // when: an unordered list is sorted
+        val sortedResult = versions.sortedWith(versionComparator)
+
+        // then: sorted list matches expected rules
+        assertEquals(
+            listOf(
+                "word",
+                "0.12",
+                "1.00",
+                "1.05",
+                "1.12-SNAPSHOT",
+                "1.12",
+                "1.20",
+                "1.20.5-SNAPSHOT"
+            ),
+            sortedResult
+        )
+    }
+
+    @Test
+    fun `should sort mixed contents in ascending order`() {
+        // given: an unordered list of versions
+        val versions = listOf(
+            "1_0_1",
+            "1.1_5_early_access",
+            "1.0.2",
+            "pre-1.12.5",
+            "pre-1.12.5-SNAPSHOT",
+            "1.1.pre.6",
+            "2.6-SNAPSHOT",
+            "1.1_7",
+            "1.1_5"
+        )
+
+        // when: an unordered list is sorted
+        val sortedResult = versions.sortedWith(versionComparator)
+
+        // then: sorted list matches expected rules
+        assertEquals(
+            listOf(
+                "pre-1.12.5-SNAPSHOT",
+                "pre-1.12.5",
+                "1_0_1",
+                "1.0.2",
+                "1.1.pre.6",
+                "1.1_5_early_access",
+                "1.1_5",
+                "1.1_7",
+                "2.6-SNAPSHOT"
+            ),
+            sortedResult
+        )
+    }
+}

--- a/reposilite-backend/src/test/kotlin/com/reposilite/storage/specification/VersionComparatorSpecification.kt
+++ b/reposilite-backend/src/test/kotlin/com/reposilite/storage/specification/VersionComparatorSpecification.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 dzikoysk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.reposilite.storage.specification
+
+import com.reposilite.storage.VersionComparator
+
+internal abstract class VersionComparatorSpecification {
+
+    val versionComparator = VersionComparator<String> { VersionComparator.asVersion(it) }
+
+}


### PR DESCRIPTION
I ran into a problem with javadoc /latest selecting version 1.19-SNAPSHOT over 1.19.3-SNAPSHOT, and after a bit of digging the problem was found to be a simple mistake. I've added a couple unit tests so I could verify that my fix had the intended effect.

One test case was modified to suit this new ordering, I don't know if that is a problem or not. By the rules of the algorithm 1.1 and 1.1.2 (release) should be newer than 1.1-SNAPSHOT, so this causes all words to be sorted to the front instead of the bottom. (might need a re-build as the auto test failed earlier because of it)