### PR TITLE
GH-1738 Add Arch Linux install instructions

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -50,6 +50,7 @@ This is simple, extensible and scalable self-hosted solution to replace managers
 </div>
 
 ### Installation
+
 To run Reposilite for your personal needs you should assign around 20MB of RAM and at least Java 11+ installed. <br>
 For huge public repositories you can adjust memory limit and even size of used thread pools in the configuration.
 
@@ -60,11 +61,6 @@ $ java -Xmx32M -jar reposilite-3.3.2.jar
 # Using the official Docker image
 $ docker pull dzikoysk/reposilite:3.3.2
 
-# Installing on Arch Linux
-$ git clone https://aur.archlinux.org/reposilite.git
-$ cd reposilite
-$ makepkg -si
-
 # Using the official Helm chart
 $ helm repo add reposilite https://helm.reposilite.com/
 $ helm repo update
@@ -72,9 +68,6 @@ $ helm install reposilite/reposilite
 ```
 
 Visit official guide to read more about extra parameters and configuration details.
-
-For more information on installing on Arch Linux, please check the
-[ArchWiki](https://wiki.archlinux.org/title/Reposilite).
 
 ### Publications
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -83,6 +83,7 @@ Reposilite 2.x:
 * [Medium / Looking for simple repository manager by David Kihato](https://kihats.medium.com/custom-self-hosted-maven-repository-cbb778031f68)
 
 ### Supporters
+
 Thanks to all contributors and people that decided to support my work financially ❤️
 
 <table>

--- a/.github/README.md
+++ b/.github/README.md
@@ -60,6 +60,11 @@ $ java -Xmx32M -jar reposilite-3.3.2.jar
 # Using the official Docker image
 $ docker pull dzikoysk/reposilite:3.3.2
 
+# Installing on Arch Linux
+$ git clone https://aur.archlinux.org/reposilite.git
+$ cd reposilite
+$ makepkg -si
+
 # Using the official Helm chart
 $ helm repo add reposilite https://helm.reposilite.com/
 $ helm repo update
@@ -67,6 +72,9 @@ $ helm install reposilite/reposilite
 ```
 
 Visit official guide to read more about extra parameters and configuration details.
+
+For more information on installing on Arch Linux, please check the
+[ArchWiki](https://wiki.archlinux.org/title/Reposilite).
 
 ### Publications
 

--- a/reposilite-site/data/guides/guides.js
+++ b/reposilite-site/data/guides/guides.js
@@ -16,6 +16,7 @@ const categories = [
       'standalone',
       'docker',
       'kubernetes',
+      'archlinux',
     ]
   },
   {

--- a/reposilite-site/data/guides/installation/archlinux.md
+++ b/reposilite-site/data/guides/installation/archlinux.md
@@ -1,0 +1,138 @@
+---
+id: archlinux
+title: Arch Linux
+---
+
+The reposilite AUR package can be found at the following sources:
+- [Github](https://github.com/reposilite-playground/reposilite-aur) -
+  releases, and official source of package
+- [AUR](https://aur.archlinux.org/packages/reposilite) - to pull
+  package using AUR helpers
+- [Polarian Onedev](https://onedev.polarian.dev/polarrepo/reposilite) -
+  mainly for development purposes from arch linux contributors, all
+  commits are pushed to github.
+
+There is a lot of different methods to install on Arch Linux, some of
+them are more complicated than others, find a list of methods below:
+
+- [From Github](/guide/archlinux#from-github)
+- [From AUR](/guide/archlinux#from-aur)
+  - [Using an AUR Helper](/guide/archlinux#using-an-aur-helper)
+  - [Building Manually](/guide/archlinux#building-manually)
+- [From PolarRepo](/guide/archlinux#from-polarrepo)
+
+## From Github
+
+AUR package builds are updated to the release section on github, see
+[Reposilite AUR Releases](https://github.com/reposilite-playground/reposilite-aur/releases).
+
+These packages are identical to which are deployed to
+[PolarRepo](/guide/archlinux#from-polarrepo), however is downloaded from
+a trusted source (github), and is reviewed by other contributors and
+developers.
+
+All install, and updates, must be done manually, using the command
+supplied within the release notes, please follow the guide on the latest
+version of the release.
+
+**Pros:**
+- Officially supported
+- Uses a trusted, and well known platform (Github)
+- Distributed as a built package, fast to install
+
+**Cons:**
+- Manual installation, and manual updates
+- Download speed is reliant on Github
+
+## From AUR
+
+There is two methods of installing from the AUR, please read both before
+making your decision on what is best for you.
+
+### Using an AUR Helper
+
+[AUR Helpers](https://wiki.archlinux.org/title/AUR_helpers) are command
+line tools which encapsulate the `pacman` package manager, and extends
+its functionality to also be able to pull and build packages from the
+AUR.
+
+There are multiple AUR helpers to pick from, see
+[Comparision Table](https://wiki.archlinux.org/title/AUR_helpers#Comparison_tables)
+for more information. For this example we will use Paru.
+
+1. Install [git](https://archlinux.org/packages/extra/x86_64/git/) and
+[base-devel](https://archlinux.org/packages/core/any/base-devel/)
+packages, these are used to build Arch Linux Packages.
+2. Clone the Paru AUR package:
+
+`git clone https://aur.archlinux.org/packages/paru`
+
+3. Build, and install the package: (will require sudo)
+
+`cd paru && makepkg -si`
+
+4. Install reposilite through Paru:
+
+`paru -Syu reposilite`
+
+This will clone, build and install reposilite automatically.
+
+Every time you need to update reposilite, execute:
+
+`paru -Syu`
+
+**NOTE:**
+- If you already have paru installed, you can ignore steps 1 to 3.
+- Paru will update itself automatically, you do not need to follow steps
+  1 to 3 once you have paru installed.
+
+**Pros:**
+- Easy to install AUR packages (not just reposilite)
+- Automaticaally updates reposilite just like `pacman` updates official
+  packages.
+
+**Cons:**
+- Packages must be built, this takes time and computational resources.
+
+### Building Manually
+
+If you do not wish to use an AUR helper, you can build the package
+manually ever release.
+
+1. Install [git](https://archlinux.org/packages/extra/x86_64/git/) and
+[base-devel](https://archlinux.org/packages/core/any/base-devel/)
+packages, these are used to build Arch Linux Packages.
+2. Clone the reposilite AUR package:
+
+`git clone https://aur.archlinux.org/packages/reposilite`
+
+3. Build, and install the package: (will require sudo)
+
+`cd reposilite && makepkg -si`
+
+You will need to follow these steps every time you want to update the
+package.
+
+**Pros:**
+- Doesn't rely on an AUR helper
+
+**Cons:**
+- Packages must be built manually every update, which can be tedious.
+- Building packages takes time and computational resources.
+
+## From PolarRepo
+
+PolarRepo is an unofficial Arch Linux Repository. It is not verified by
+any Arch Linux staff, nor reposilite developers, use at your own risk.
+
+To use PolarRepo, follow their [setup guide](https://onedev.polarian.dev/polarrepo#getting-started).
+
+**Pros:**
+- Prebuilt package, fast to install.
+- Updates automatically handled by the `pacman` package manager, which
+  is the official package manager for Arch Linux.
+
+**Cons:**
+- Unofficial repository, uptime and download speeds may vary and can not
+  be relied upon.
+- Unverified, **use at your own risk!**


### PR DESCRIPTION
For a while now there has been an AUR package for reposilite, to aid in the installing on Arch (and arch based distributions).

I have added the basic installation from the AUR (without an AUR helper) however I have also left a link to the Arch Wiki which has a lot of information on the installation process on Arch Linux.

As for me, I am the co-maintainer of the AUR package, and I am the maintainer of the reposilite ArchWiki page, so any issues with it please let me know.

Any issues with the AUR package can be submitted on the repository here: https://onedev.polarian.dev/polarrepo/reposilite

You can also install reposilite directly, already packaged, from PolarRepo (an unofficial arch repository which I maintain to aid in installation of AUR packages I maintain), for more information check this link: https://onedev.polarian.dev/polarrepo/~files

Good luck with the development of Reposilite :)