### PR TITLE
GH-1758 Add human-readable names for Gradle snippets

### DIFF
--- a/reposilite-frontend/src/components/card/RepositorySnippet.vue
+++ b/reposilite-frontend/src/components/card/RepositorySnippet.vue
@@ -41,11 +41,13 @@ defineProps({
 </pre>
 <pre v-else-if="configuration.lang === 'groovy'">
 maven <CodeBrackets start="{" end="}">
+    name <CodeString>{{ data.title }}</CodeString>
     url <CodeString>{{ data.domain }}</CodeString>
 </CodeBrackets>
 </pre>
 <pre v-else-if="configuration.lang === 'kotlin'">
 maven <CodeBrackets start="{" end="}">
+    name = <CodeString>{{ data.title }}</CodeString>
     url = uri<CodeBrackets start="(" end=")"><CodeString>{{ data.domain }}</CodeString></CodeBrackets>
 </CodeBrackets>
 </pre>

--- a/reposilite-frontend/src/components/card/RepositorySnippet.vue
+++ b/reposilite-frontend/src/components/card/RepositorySnippet.vue
@@ -18,8 +18,9 @@
 import XmlTag from './XmlTag.vue'
 import CodeString from './CodeString.vue'
 import CodeBrackets from "./CodeBrackets.vue"
+import {computed} from 'vue'
 
-defineProps({
+const props = defineProps({
   configuration: {
     type: Object,
     required: true
@@ -29,6 +30,16 @@ defineProps({
     required: true
   }
 })
+
+const gradleId = computed(() => {
+  const gradleIdUppercase = props.data.repoId
+      .split('-')
+      .map(it => it.charAt(0).toUpperCase() + it.slice(1))
+      .join('')
+
+  return gradleIdUppercase.charAt(0).toLowerCase() + gradleIdUppercase.slice(1)
+})
+
 </script>
 
 <template>
@@ -41,13 +52,13 @@ defineProps({
 </pre>
 <pre v-else-if="configuration.lang === 'groovy'">
 maven <CodeBrackets start="{" end="}">
-    name <CodeString>{{ data.title }}</CodeString>
+    name <CodeString>{{ gradleId }}</CodeString>
     url <CodeString>{{ data.domain }}</CodeString>
 </CodeBrackets>
 </pre>
 <pre v-else-if="configuration.lang === 'kotlin'">
 maven <CodeBrackets start="{" end="}">
-    name = <CodeString>{{ data.title }}</CodeString>
+    name = <CodeString>{{ gradleId }}</CodeString>
     url = uri<CodeBrackets start="(" end=")"><CodeString>{{ data.domain }}</CodeString></CodeBrackets>
 </CodeBrackets>
 </pre>

--- a/reposilite-frontend/src/components/card/SnippetsCard.vue
+++ b/reposilite-frontend/src/components/card/SnippetsCard.vue
@@ -68,7 +68,7 @@ watchEffect(() => {
   const qualifier = props.qualifier.path
   const elements = qualifier.split('/')
 
-  if (elements.length == 1 && elements[0] == '') {
+  if (elements.length === 1 && elements[0] == '') {
     displayRepository()
     return
   }

--- a/reposilite-frontend/src/store/maven/repository.js
+++ b/reposilite-frontend/src/store/maven/repository.js
@@ -29,7 +29,7 @@ export default function useRepository() {
       location.host +
       basePath +
       (basePath.endsWith("/") ? "" : "/") +
-      (qualifier.path ? `${repository.value}` : "{repository}")
+      (qualifier.path ? `${repository.value}` : "<repository>")
 
     return { type: "repository", repoId, title, domain }
   }

--- a/reposilite-frontend/vite.config.js
+++ b/reposilite-frontend/vite.config.js
@@ -41,6 +41,7 @@ export default defineConfig({
     minify: true,
     emptyOutDir: true,
     outDir: "build/frontend/reposilite-frontend",
+    chunkSizeWarningLimit: 550
   },
   css: {
     preprocessorOptions: {


### PR DESCRIPTION
See #1758. A simple change.

Before:
![Screenshot 2023-03-24 at 21-00-51 {{REPOSILITE TITLE}}](https://user-images.githubusercontent.com/5115825/227643494-02a60e49-6643-415a-8615-96a0757954db.png)
![Screenshot 2023-03-24 at 21-00-56 {{REPOSILITE TITLE}}](https://user-images.githubusercontent.com/5115825/227643502-670f707c-211f-4037-8566-3614c4513b2d.png)

After:
![Screenshot 2023-03-24 at 21-02-29 {{REPOSILITE TITLE}}](https://user-images.githubusercontent.com/5115825/227643532-035f7884-e06c-45e6-8dea-e71b2ef5e9ee.png)
![Screenshot 2023-03-24 at 21-04-04 {{REPOSILITE TITLE}}](https://user-images.githubusercontent.com/5115825/227643539-04bddcef-3926-4c6d-8b17-df38145bcdb9.png)
