### PR TITLE
Add SVG as supported javadoc type

### DIFF
--- a/reposilite-backend/src/main/kotlin/com/reposilite/javadocs/JavadocFacade.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/javadocs/JavadocFacade.kt
@@ -36,7 +36,6 @@ import panda.std.Result
 import panda.std.Result.supplyThrowing
 import panda.std.asSuccess
 import panda.utilities.StringUtils
-import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -54,6 +53,7 @@ class JavadocFacade internal constructor(
         "css" to ContentType.TEXT_CSS,
         "js" to ContentType.TEXT_JS,
         "png" to ContentType.IMAGE_PNG,
+        "svg" to ContentType.IMAGE_SVG,
     )
 
     private data class JavadocPlainFile(


### PR DESCRIPTION
Some javadoc doclets and taglets produce SVG images. This PR adds support for them.
Tested by publishing a project using one such doclet to an instance of reposilite with this change and verifying that it is displayed correctly.
There is one oddity in the embedded view: links in the SVG do not work, while links outside it do.
This is, however, not an issue in the raw view.