### PR TITLE
Fix badges having a black background if no custom color is provided

### DIFF
--- a/reposilite-backend/src/main/kotlin/com/reposilite/shared/BadgeGenerator.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/shared/BadgeGenerator.kt
@@ -70,7 +70,7 @@ object BadgeGenerator {
                     </clipPath>
                     <g clip-path="url(#r)">
                         <rect width="$nameWidth" height="20" fill="#555"/>
-                        <rect x="$nameWidth" width="$valueWidth" height="20" fill="#$optionalColor"/>
+                        <rect x="$nameWidth" width="$valueWidth" height="20" fill="#$color"/>
                         <rect width="$fullWidth" height="20" fill="url(#s)"/>
                     </g>
                     <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110"> 


### PR DESCRIPTION
If no custom color is provided the returned SVG document looks like this:
```xml
<g clip-path="url(#r)">
    <rect width="98" height="20" fill="#555"/>
    <rect x="98" width="49" height="20" fill="#null"/>
    <rect width="147" height="20" fill="url(#s)"/>
</g> 
```
with an fill color of `#null` which makes the background black
Example:
![](https://maven.reposilite.com/api/badge/latest/releases/com/reposilite/reposilite)