### PR TITLE
Prettier uptime format

### DIFF
--- a/reposilite-backend/src/main/kotlin/com/reposilite/shared/extensions/TimeUtils.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/shared/extensions/TimeUtils.kt
@@ -15,6 +15,8 @@
  */
 package com.reposilite.shared.extensions
 
+import java.time.Duration
+import java.time.Instant
 import java.util.Locale
 
 internal object TimeUtils {
@@ -28,8 +30,36 @@ internal object TimeUtils {
     fun getPrettyUptimeInSeconds(startTime: Long): String =
         format(getUptimeInSeconds(startTime)) + "s"
 
-    fun getPrettyUptimeInMinutes(startTime: Long): String =
-        format(getUptimeInSeconds(startTime) / 60) + "min"
+    fun getPrettyUptime(startTime: Long): String {
+        val currentTimestamp = Instant.now().toEpochMilli()
+        val uptimeMillis = currentTimestamp - startTime
+
+        val uptimeDuration = Duration.ofMillis(uptimeMillis)
+        val days = uptimeDuration.toDays()
+        val hours = uptimeDuration.toHours() % 24
+        val minutes = uptimeDuration.toMinutes() % 60
+        val seconds = uptimeDuration.seconds % 60
+
+        val uptimeStringBuilder = StringBuilder()
+
+        if (days > 0) {
+            uptimeStringBuilder.append(days).append("d ")
+        }
+
+        if (hours > 0) {
+            uptimeStringBuilder.append(hours).append("h ")
+        }
+
+        if (minutes > 0) {
+            uptimeStringBuilder.append(minutes).append("min ")
+        }
+
+        if (seconds > 0 || days == 0L && hours == 0L && minutes == 0L) {
+            uptimeStringBuilder.append(seconds).append("s")
+        }
+
+        return uptimeStringBuilder.toString().trim()
+    }
 
     fun format(time: Double): String =
         String.format(Locale.US, "%.2f", time)

--- a/reposilite-backend/src/main/kotlin/com/reposilite/status/StatusCommand.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/status/StatusCommand.kt
@@ -33,7 +33,7 @@ internal class StatusCommand(private val statusFacade: StatusFacade) : Reposilit
         statusFacade.fetchInstanceStatus().apply {
             context.append("Reposilite $VERSION Status")
             context.append("  Active: $GREEN_BOLD${statusFacade.isAlive()}$RESET")
-            context.append("  Uptime: ${TimeUtils.getPrettyUptimeInMinutes(statusFacade.getUptime())}")
+            context.append("  Uptime: ${TimeUtils.getPrettyUptime(statusFacade.getUptime())}")
             context.append("  Memory usage of process: ${TimeUtils.format(usedMemory)}M")
             context.append("  Active threads in group: $usedThreads")
             context.append("  Recorded failures: $failuresCount")

--- a/reposilite-backend/src/main/kotlin/com/reposilite/status/application/StatusPlugin.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/status/application/StatusPlugin.kt
@@ -100,7 +100,7 @@ internal class StatusPlugin : ReposilitePlugin() {
         }
 
         event { _: HttpServerStoppedEvent ->
-            logger.info("Bye! Uptime: " + TimeUtils.getPrettyUptimeInMinutes(statusFacade.getUptime()))
+            logger.info("Bye! Uptime: " + TimeUtils.getPrettyUptime(statusFacade.getUptime()))
         }
 
         return statusFacade

--- a/reposilite-frontend/src/components/dashboard/InstanceStatusCharts.vue
+++ b/reposilite-frontend/src/components/dashboard/InstanceStatusCharts.vue
@@ -30,16 +30,18 @@ function requestStatus() {
 }
 requestStatus()
 
-const secondsToHms = (seconds) => {
-    const h = Math.floor(seconds / 3600)
-    const m = Math.floor(seconds % 3600 / 60)
-    const s = Math.floor(seconds % 3600 % 60)
+const prettyUptime = (seconds) => {
+    const d = Math.floor(seconds / 86400)
+    const h = Math.floor((seconds % 86400) / 3600)
+    const m = Math.floor(((seconds % 86400) % 3600) / 60)
+    const s = Math.floor(((seconds % 86400) % 3600) % 60)
 
+    const dDisplay = d > 0 ? d + "d " : ""
     const hDisplay = h > 0 ? h + "h " : ""
     const mDisplay = m > 0 ? m + "min " : ""
     const sDisplay = s > 0 ? s + "s" : ""
-    
-    return hDisplay + mDisplay + sDisplay
+
+    return dDisplay + hDisplay + mDisplay + sDisplay
 }
 </script>
 
@@ -53,7 +55,7 @@ const secondsToHms = (seconds) => {
       />
       <DashboardBox 
         title="Uptime"
-        :content="secondsToHms(instanceStatus.uptime / 1000)"
+        :content="prettyUptime(instanceStatus.uptime / 1000)"
       />
       <DashboardBox 
         title="Used memory"


### PR DESCRIPTION
Added days to the uptime in the frontend dashboard.
Made the uptime in the status command the same format (`2d 8h 42min 5s`).