### PR TITLE
Disable auto complete for consoleInput

### DIFF
--- a/reposilite-frontend/src/components/console/ConsoleView.vue
+++ b/reposilite-frontend/src/components/console/ConsoleView.vue
@@ -103,6 +103,7 @@ watch(
         id="consoleInput"
         placeholder="Type command or '?' to get help"
         class="w-full py-2 px-4 rounded-b-lg bg-white dark:bg-gray-900 dark:text-white"
+        autocomplete="off"
         v-model="command"
         @keyup.enter="execute()"
         @keyup.up="previousCommand()"


### PR DESCRIPTION
These autocomplete pop-ups are very annoying. They can prevent you from using the `↑` or `↓` keys to switch within the command history.

![image](https://github.com/dzikoysk/reposilite/assets/28978806/9924abd4-3bc1-4336-bce6-6687c312d974)

In my opinion, the command input box is not really a form. It's an interactive command input, which doesn't need any browser-provided autocomplete.

So, here's a quick fix for that: set `autocomplete="off"` and that's it.
