### PR TITLE
GH-1925 Fix Docker entrypoint.sh root check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ VOLUME /app/data
 WORKDIR /app
 COPY --from=build /home/reposilite-build/reposilite-backend/build/libs/reposilite-3*.jar reposilite.jar
 COPY --from=build /home/reposilite-build/entrypoint.sh entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 RUN apt-get update && apt-get -y install util-linux curl
 HEALTHCHECK --interval=30s --timeout=30s --start-period=15s \
     --retries=3 CMD [ "sh", "-c", "URL=$(cat /app/data/.local/reposilite.address); echo -n \"curl $URL... \"; \
@@ -38,5 +39,5 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=15s \
     ) && echo OK || (\
         echo Fail && exit 2\
     )"]
-ENTRYPOINT ["/bin/sh", "entrypoint.sh"]
+ENTRYPOINT ["/app/entrypoint.sh"]
 CMD []

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 REPOSILITE_ARGS="$REPOSILITE_OPTS"
 case "$REPOSILITE_OPTS" in


### PR DESCRIPTION
The actual root cause was that the shebang/hash-bang line in `entrypoint.sh` was not taken into account. This happened because the ENTRYPOINT didn't open a sub-shell like `["/bin/sh", "-c", "/app/entrypoint.sh"]` (not the missing "-c"). Using a sub-shell would introduce another call tree process to the Docker container runtime and is not necessary.
Instead, `["/app/entrypoint.sh"]` is enough to get Reposilite started through an actual bash, like intended with the shebang line in that script.

Doing so resolves the root check issue and identified another issue with the Docker image where the entrypoint file hadn't reliable execute permissions.

Resolves #1924.