### PR TITLE
GH-1926 Fix tinylog file size policy

### DIFF
--- a/reposilite-backend/src/main/resources/tinylog.properties
+++ b/reposilite-backend/src/main/resources/tinylog.properties
@@ -26,9 +26,8 @@ writerFile.level = debug
 writerFile.format = {class} {date: yyyy-MM-dd HH:mm:ss.SSS} {level} | {message}
 writerFile.file = ./logs/log_{date}.txt
 writerFile.latest = latest.log
-writerFile.size = 100 MB
 writerFile.backups = 10
-writerFile.policies = startup, monthly: 03:00
+writerFile.policies = size: 100mb, startup, monthly: 03:00
 writerFile.convert = gzip
 
 


### PR DESCRIPTION
The `writerFile.size` has no effect as I've observed the logs far exceeding the default `100MB` limit.

This changes to use the [documented](https://tinylog.org/v2/configuration/#policies) `size` policy.

