### PR TITLE
GH-1934 Check if user/group already exist in entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,10 +17,18 @@ if [ "$UID" -ne "0" ]; then
        $REPOSILITE_ARGS
 else
   GROUP_ID="${PGID:-999}"
-  addgroup --gid "$GROUP_ID" reposilite
+  grep "^reposilite" /etc/group > /dev/null
+  if [ $? -ne 0 ]
+  then
+    addgroup --gid "$GROUP_ID" reposilite
+  fi
 
   USER_ID="${PUID:-999}"
-  adduser --system -uid "$USER_ID" --ingroup reposilite --shell /bin/sh reposilite
+  grep "^reposilite" /etc/passwd > /dev/null
+  if [ $? -ne 0 ]
+  then
+    adduser --system -uid "$USER_ID" --ingroup reposilite --shell /bin/sh reposilite
+  fi
 
   chown -R reposilite:reposilite /app
   chown -R reposilite:reposilite /var/log/reposilite


### PR DESCRIPTION
Fix the error when starting the container for the second time： addgroup: The group `reposilite' already exists.

![image](https://github.com/dzikoysk/reposilite/assets/12333292/7d31c9c8-e178-4cbb-badc-3716adcc813d)
![image](https://github.com/dzikoysk/reposilite/assets/12333292/2badf8c6-09f0-48bc-a490-2d2afe9cd8d9)
