### PR TITLE
Update Dockerfile Add EXPOSE 8080

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,3 +41,4 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=15s \
     )"]
 ENTRYPOINT ["/app/entrypoint.sh"]
 CMD []
+EXPOSE 8080


### PR DESCRIPTION
Fixed the problem of missing public port configuration, causing Docker UI to be unable to recognize the application service port

![image](https://github.com/dzikoysk/reposilite/assets/12333292/177f1599-d663-4bec-9220-bbaef85e025f)
