### PR TITLE
GH-1982 Make `organizationWebsite` open in new tab

### DIFF
--- a/reposilite-frontend/src/components/header/HeaderHero.vue
+++ b/reposilite-frontend/src/components/header/HeaderHero.vue
@@ -33,7 +33,7 @@ const { description, organizationWebsite, organizationLogo } = usePlaceholders()
         </div>
         <div class="flex flex-row py-2 <sm:justify-center">
           <GlobeIcon />
-          <a class="px-3 text-gray-500" :href="organizationWebsite">{{organizationWebsite}}</a>
+          <a class="px-3 text-gray-500" :href="organizationWebsite" target="_blank">{{organizationWebsite}}</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This makes it so that the organization website link opens in a new tab when clicked, rather than replacing the current tab.