### PR TITLE
GH-2042 Fix logic in isMetadataFileValid

### DIFF
--- a/reposilite-backend/src/main/kotlin/com/reposilite/maven/MirrorService.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/maven/MirrorService.kt
@@ -50,7 +50,7 @@ internal class MirrorService(
     private fun isMetadataFileValid(repository: Repository, gav: Location): Boolean =
         repository.storageProvider.getLastModifiedTime(gav)
             .map { it.toInstant().plus(repository.metadataMaxAgeInSeconds, ChronoUnit.SECONDS) }
-            .matches { it.isBefore(Instant.now(clock)) }
+            .matches { it.isAfter(Instant.now(clock)) }
 
     fun findRemoteDetails(repository: Repository, gav: Location): Result<FileDetails, ErrorResponse> =
         searchInRemoteRepositories(repository, gav) { (host, config, client) ->


### PR DESCRIPTION
The logic was in reverse. The file is valid when it is older than the defined time-range.

This commit reverses the logic and makes the feature usable.