### PR TITLE
Fix broken link

### DIFF
--- a/reposilite-site/data/guides/installation/general.md
+++ b/reposilite-site/data/guides/installation/general.md
@@ -5,7 +5,7 @@ title: General
 
 Reposilite supports multiple use cases and environments. By default we support 3 of them:
 
-* [Standalone](/guide/standalone) - run regular JAR file as standalone Java application
+* [Standalone](/guide/jar) - run regular JAR file as standalone Java application
 * [Docker](/guide/docker) - launch Reposilite within Docker container
 * [Kubernetes](/guide/kubernetes) - manage multiple Reposilite instances using Kubernetes
 


### PR DESCRIPTION
Fix https://reposilite.com/guide/general "Standalone" link taking you to `/standalone` instead of `/jar` which it should.