### PR TITLE
GH-2222 Added line breaks to docker command

### DIFF
--- a/reposilite-site/data/guides/installation/docker.md
+++ b/reposilite-site/data/guides/installation/docker.md
@@ -75,8 +75,8 @@ To launch Reposilite with a custom configuration, we have to mount proper file:
 $ docker run -it \
   --mount type=bind,source=/etc/reposilite/configuration.cdn,target=/app/configuration.cdn \
   -e REPOSILITE_OPTS='--local-configuration=/app/configuration.cdn' \
-  -v reposilite-data:/app/data
-  -p 80:8080
+  -v reposilite-data:/app/data \
+  -p 80:8080 \
   dzikoysk/reposilite
 ```
 


### PR DESCRIPTION
Added line break char ('\\') to docker run command. Copy pasting the command will now work instead of failing.