### PR TITLE
GH-2275 Use file api from kotlin stdlib

### DIFF
--- a/reposilite-backend/src/integration/kotlin/com/reposilite/configuration/StartupParametersIntegrationTest.kt
+++ b/reposilite-backend/src/integration/kotlin/com/reposilite/configuration/StartupParametersIntegrationTest.kt
@@ -18,24 +18,23 @@
 
 package com.reposilite.configuration
 
+import com.reposilite.RecommendedLocalSpecificationJunitExtension
 import com.reposilite.ReposiliteParameters
+import com.reposilite.ReposiliteSpecification
 import com.reposilite.configuration.shared.SharedConfigurationFacade
 import com.reposilite.frontend.application.FrontendSettings
-import com.reposilite.RecommendedLocalSpecificationJunitExtension
-import com.reposilite.ReposiliteSpecification
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import java.nio.file.Files
 
 @ExtendWith(RecommendedLocalSpecificationJunitExtension::class)
 internal class StartupParametersIntegrationTest : ReposiliteSpecification() {
 
     override fun overrideParameters(parameters: ReposiliteParameters) {
         // given: a custom shared configuration
-        parameters.sharedConfigurationPath = reposiliteWorkingDirectory.resolve("custom-shared-configuration.json").toPath()
-        Files.writeString(
-            parameters.sharedConfigurationPath,
+        val sharedConfiguration = reposiliteWorkingDirectory.resolve("custom-shared-configuration.json")
+        parameters.sharedConfigurationPath = sharedConfiguration.toPath()
+        sharedConfiguration.writeText(
             """
             {
                 "frontend": {

--- a/reposilite-backend/src/main/kotlin/com/reposilite/ReposiliteJournalist.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/ReposiliteJournalist.kt
@@ -30,19 +30,19 @@ import org.slf4j.LoggerFactory
 import org.tinylog.provider.ProviderRegistry
 import panda.std.reactive.Subscriber
 import java.io.PrintStream
-import java.nio.file.Files
 import kotlin.collections.MutableMap.MutableEntry
+import kotlin.io.path.createTempFile
 
 /**
- * Initializes quite complicated flow of logging used in Reposilite.
- * The order of processing is as follows:
- *
+ * Initializes quite complicated flow of logging used in Reposilite. The
+ * order of processing is as follows:
  * 1. Message is sent to ReposiliteLogger
- * 2. Message is redirected to the standard SL4J implementation
- *   2.1 SLF4J writes every log entry to the log.txt file
- * 3. Message is caught by TinyLog wrapper and redirected to the rest of loggers
- *   3.1 Cached logger catches all messages and stores them in memory
- *   3.2 Visible logger prints messages that fulfills threshold requirements in the console
+ * 2. Message is redirected to the standard SL4J implementation 2.1 SLF4J
+ *    writes every log entry to the log.txt file
+ * 3. Message is caught by TinyLog wrapper and redirected to the rest of
+ *    loggers 3.1 Cached logger catches all messages and stores them in
+ *    memory 3.2 Visible logger prints messages that fulfills threshold
+ *    requirements in the console
  */
 class ReposiliteJournalist(
     visibleJournalist: Journalist,
@@ -72,7 +72,7 @@ class ReposiliteJournalist(
 
         this.mainLogger =
             if (testEnv)
-                PrintStreamLogger(PrintStream(Files.createTempFile("reposilite", "test-out").toFile()), System.err)
+                PrintStreamLogger(PrintStream(createTempFile("reposilite", "test-out").toFile()), System.err)
             else
                 Slf4jLogger(LoggerFactory.getLogger(Reposilite::class.java))
     }

--- a/reposilite-backend/src/main/kotlin/com/reposilite/configuration/ConfigurationUtils.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/configuration/ConfigurationUtils.kt
@@ -27,8 +27,8 @@ import com.reposilite.plugin.api.Plugin
 import com.reposilite.plugin.api.ReposilitePlugin
 import net.dzikoysk.cdn.KCdnFactory
 import net.dzikoysk.cdn.source.Source
-import java.nio.file.Files
 import java.util.ServiceLoader
+import kotlin.io.path.writeText
 import kotlin.reflect.full.createInstance
 import kotlin.reflect.full.findAnnotation
 
@@ -50,7 +50,7 @@ internal fun generateRequestedConfiguration(parameters: ReposiliteParameters) {
                 .mapValues { (_, type) -> type.createInstance() }
                 .let { ReposiliteObjectMapper.DEFAULT_OBJECT_MAPPER.valueToTree<JsonNode>(it) }
                 .toPrettyString()
-                .also { Files.writeString(sharedConfigurationFile, it) }
+                .also { sharedConfigurationFile.writeText(it) }
             println("Shared configuration has been generated to the $sharedConfigurationFile file")
         }
         else -> println("Unknown configuration: ${parameters.configurationRequested}")

--- a/reposilite-backend/src/main/kotlin/com/reposilite/configuration/shared/infrastructure/LocalSharedConfigurationProvider.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/configuration/shared/infrastructure/LocalSharedConfigurationProvider.kt
@@ -18,9 +18,10 @@ package com.reposilite.configuration.shared.infrastructure
 
 import com.reposilite.configuration.shared.SharedConfigurationProvider
 import com.reposilite.journalist.Journalist
-import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.exists
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
 
 const val SHARED_CONFIGURATION_FILE = "configuration.shared.json"
 
@@ -31,13 +32,13 @@ class LocalSharedConfigurationProvider(
 ) : SharedConfigurationProvider {
 
     override fun updateConfiguration(content: String) {
-        Files.writeString(workingDirectory.resolve(configurationFile), content)
+        workingDirectory.resolve(configurationFile).writeText(content)
     }
 
     override fun fetchConfiguration(): String =
         workingDirectory.resolve(configurationFile)
             .takeIf { it.exists() }
-            ?.let { Files.readString(it) }
+            ?.readText()
             ?: ""
 
     override fun isUpdateRequired(): Boolean =

--- a/reposilite-backend/src/main/kotlin/com/reposilite/frontend/LazyPlaceholderResolver.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/frontend/LazyPlaceholderResolver.kt
@@ -22,8 +22,9 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.nio.charset.MalformedInputException
 import java.nio.charset.StandardCharsets.UTF_8
-import java.nio.file.Files
-import java.nio.file.StandardOpenOption
+import kotlin.io.path.createTempFile
+import kotlin.io.path.inputStream
+import kotlin.io.path.outputStream
 
 internal class LazyPlaceholderResolver(private val placeholders: Map<String, String>) {
 
@@ -38,17 +39,17 @@ internal class LazyPlaceholderResolver(private val placeholders: Map<String, Str
         ?: 0
 
     fun createProcessedResource(input: InputStream): ResourceSupplier {
-        val temporaryResourcePath = Files.createTempFile("reposilite", "frontend-resource")
+        val temporaryResourcePath = createTempFile("reposilite", "frontend-resource")
 
         input.use { inputStream ->
-            Files.newOutputStream(temporaryResourcePath, StandardOpenOption.WRITE).use { outputStream ->
+            temporaryResourcePath.outputStream().use { outputStream ->
                 process(inputStream, outputStream)
             }
         }
 
         return ResourceSupplier {
             Result.supplyThrowing(IOException::class.java) {
-                Files.newInputStream(temporaryResourcePath)
+                temporaryResourcePath.inputStream()
             }
         }
     }

--- a/reposilite-backend/src/main/kotlin/com/reposilite/frontend/application/FrontendPlugin.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/frontend/application/FrontendPlugin.kt
@@ -33,9 +33,10 @@ import com.reposilite.web.api.HttpServerInitializationEvent
 import com.reposilite.web.api.ReposiliteRoutes
 import com.reposilite.web.api.RoutingSetupEvent
 import io.javalin.http.NotFoundResponse
-import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.createDirectory
 import kotlin.io.path.exists
+import kotlin.io.path.outputStream
 
 @Plugin(name = "frontend", dependencies = ["local-configuration", "shared-configuration", "failure"], settings = FrontendSettings::class)
 internal class FrontendPlugin : ReposilitePlugin() {
@@ -63,7 +64,7 @@ internal class FrontendPlugin : ReposilitePlugin() {
 
             staticDirectory
                 .takeUnless { it.exists() }
-                ?.also { Files.createDirectory(it) }
+                ?.also { it.createDirectory() }
                 ?.also { copyResourceTo(INDEX, it.resolve(INDEX)) }
 
             staticDirectory.resolve(FAVICON)
@@ -107,7 +108,7 @@ internal class FrontendPlugin : ReposilitePlugin() {
 
     private fun copyResourceTo(file: String, to: Path) {
         Reposilite::class.java.getResourceAsStream("/$STATIC_DIRECTORY/$file")?.use {
-            Files.copy(it, to)
+            it.transferTo(to.outputStream())
         }
     }
 

--- a/reposilite-backend/src/main/kotlin/com/reposilite/status/application/StatusPlugin.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/status/application/StatusPlugin.kt
@@ -38,12 +38,13 @@ import com.reposilite.status.infrastructure.StatusEndpoints
 import com.reposilite.web.HttpServer
 import com.reposilite.web.api.HttpServerStoppedEvent
 import com.reposilite.web.api.RoutingSetupEvent
-import java.nio.file.Files
-import java.nio.file.StandardOpenOption
 import panda.std.reactive.Completable
 import panda.std.reactive.Reference.Dependencies.dependencies
 import panda.std.reactive.Reference.computed
 import panda.utilities.console.Effect
+import java.nio.file.StandardOpenOption
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
 
 @Plugin(name = "status", dependencies = ["console", "failure", "local-configuration"])
 internal class StatusPlugin : ReposilitePlugin() {
@@ -100,12 +101,12 @@ internal class StatusPlugin : ReposilitePlugin() {
 
         event { _: ReposiliteStartedEvent ->
             val localTmpDataDirectory = parameters().workingDirectory.resolve(".local")
-            Files.createDirectories(localTmpDataDirectory)
+            localTmpDataDirectory.createDirectories()
 
-            Files.writeString(
-                localTmpDataDirectory.resolve("reposilite.address"),
+            val reposiliteAddressFile = localTmpDataDirectory.resolve("reposilite.address")
+            reposiliteAddressFile.writeText(
                 "${parameters().hostname}:${parameters().port}",
-                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.SYNC
+                options = arrayOf(StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.SYNC)
             )
         }
 

--- a/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemQuotaProviders.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemQuotaProviders.kt
@@ -20,9 +20,9 @@ import com.reposilite.journalist.Journalist
 import com.reposilite.shared.ErrorResponse
 import com.reposilite.shared.toErrorResponse
 import io.javalin.http.HttpStatus.INSUFFICIENT_STORAGE
-import java.nio.file.Files
-import java.nio.file.Path
 import panda.std.Result
+import java.nio.file.Path
+import kotlin.io.path.fileStore
 
 /**
  * @param rootDirectory root directory of storage space
@@ -76,7 +76,7 @@ internal class PercentageQuota(
     override fun canHold(contentLength: Long): Result<Long, ErrorResponse> =
         usage()
             .map { usage ->
-                val capacity = Files.getFileStore(rootDirectory).usableSpace
+                val capacity = rootDirectory.fileStore().usableSpace
                 val max = capacity * maxPercentage
                 max.toLong() - usage
             }

--- a/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemStorageProviderFactory.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemStorageProviderFactory.kt
@@ -19,9 +19,9 @@ package com.reposilite.storage.filesystem
 import com.reposilite.journalist.Journalist
 import com.reposilite.status.FailureFacade
 import com.reposilite.storage.StorageProviderFactory
-import java.nio.file.Files
 import java.nio.file.Path
 import java.util.regex.Pattern
+import kotlin.io.path.createDirectories
 
 class FileSystemStorageProviderFactory : StorageProviderFactory<FileSystemStorageProvider, FileSystemStorageProviderSettings> {
 
@@ -107,7 +107,7 @@ class FileSystemStorageProviderFactory : StorageProviderFactory<FileSystemStorag
             else
                 workingDirectory.resolve(settings.mount)
 
-        Files.createDirectories(repositoryDirectory)
+        repositoryDirectory.createDirectories()
 
         return of(
             journalist = journalist,

--- a/reposilite-backend/src/main/kotlin/com/reposilite/token/ExportService.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/token/ExportService.kt
@@ -26,17 +26,17 @@ import panda.std.Result
 import panda.std.Result.supplyThrowing
 import picocli.CommandLine.Command
 import picocli.CommandLine.Parameters
-import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption.CREATE
 import java.nio.file.StandardOpenOption.TRUNCATE_EXISTING
 import kotlin.io.path.absolute
 import kotlin.io.path.readText
+import kotlin.io.path.writeText
 
 class ExportService {
 
     fun exportToFile(tokens: Collection<AccessTokenDetails>, toFile: Path): Path =
-        Files.writeString(toFile, DEFAULT_OBJECT_MAPPER.writeValueAsString(tokens), TRUNCATE_EXISTING, CREATE)
+        toFile.also { it.writeText(DEFAULT_OBJECT_MAPPER.writeValueAsString(tokens), options = arrayOf(TRUNCATE_EXISTING, CREATE)) }
 
     fun importFromFile(fromFile: Path): Result<Collection<AccessTokenDetails>, Exception> =
         supplyThrowing { DEFAULT_OBJECT_MAPPER.readValue<List<AccessTokenDetails>>(fromFile.readText()) }

--- a/reposilite-backend/src/test/kotlin/com/reposilite/maven/specification/MavenSpecification.kt
+++ b/reposilite-backend/src/test/kotlin/com/reposilite/maven/specification/MavenSpecification.kt
@@ -57,8 +57,10 @@ import panda.std.reactive.Reference
 import panda.std.reactive.reference
 import panda.std.reactive.toReference
 import java.io.File
-import java.nio.file.Files
 import java.time.Clock
+import kotlin.io.path.createFile
+import kotlin.io.path.createParentDirectories
+import kotlin.io.path.writeText
 
 internal abstract class MavenSpecification {
 
@@ -167,9 +169,9 @@ internal abstract class MavenSpecification {
             .resolve(fileSpec.repository)
             .resolve(fileSpec.gav.toLocation().toPath().get())
             .also {
-                Files.createDirectories(it.parent)
-                Files.createFile(it)
-                Files.write(it, fileSpec.content.toByteArray())
+                it.createParentDirectories()
+                it.createFile()
+                it.writeText(fileSpec.content)
             }
 
         return fileSpec

--- a/reposilite-backend/src/test/kotlin/com/reposilite/token/ExportAndImportTest.kt
+++ b/reposilite-backend/src/test/kotlin/com/reposilite/token/ExportAndImportTest.kt
@@ -7,7 +7,7 @@ import com.reposilite.token.RoutePermission.READ
 import com.reposilite.token.specification.AccessTokenSpecification
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.nio.file.Files
+import kotlin.io.path.exists
 
 internal class ExportAndImportTest : AccessTokenSpecification() {
 
@@ -26,18 +26,18 @@ internal class ExportAndImportTest : AccessTokenSpecification() {
         val context = CommandContext()
 
         // when: tokens are exported to file
-        val exportCommand = ExportTokensCommand(workingDirectory(), accessTokenFacade).also { it.name = fileName }
+        val exportCommand = ExportTokensCommand(workingDirectory, accessTokenFacade).also { it.name = fileName }
         exportCommand.execute(context)
 
         // then: tokens were successfully exported
         assertThat(context.status).isEqualTo(SUCCEEDED)
-        assertThat(Files.exists(workingDirectory.toPath().resolve(fileName))).isTrue
+        assertThat(workingDirectory.resolve(fileName).exists()).isTrue
 
         // given: a facade without tokens
         deleteAllTokens()
 
         // when: exported tokens are imported from the given file
-        val importCommand = ImportTokensCommand(workingDirectory(), accessTokenFacade).also { it.name = fileName }
+        val importCommand = ImportTokensCommand(workingDirectory, accessTokenFacade).also { it.name = fileName }
         importCommand.execute(context)
 
         // then: the imported tokens match the old ones

--- a/reposilite-backend/src/test/kotlin/com/reposilite/token/specification/AccessTokenSpecification.kt
+++ b/reposilite-backend/src/test/kotlin/com/reposilite/token/specification/AccessTokenSpecification.kt
@@ -26,16 +26,15 @@ import com.reposilite.token.api.AccessTokenDto
 import com.reposilite.token.api.CreateAccessTokenRequest
 import com.reposilite.token.api.CreateAccessTokenResponse
 import com.reposilite.token.infrastructure.InMemoryAccessTokenRepository
-import java.io.File
-import java.nio.file.Path
 import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
 
 internal abstract class AccessTokenSpecification {
 
     val logger = AggregatedLogger(InMemoryLogger(), PrintStreamLogger(System.out, System.out))
 
     @TempDir
-    lateinit var workingDirectory: File
+    lateinit var workingDirectory: Path
     var accessTokenFacade: AccessTokenFacade = AccessTokenFacade(logger, InMemoryAccessTokenRepository(), InMemoryAccessTokenRepository(), ExportService())
 
     fun createToken(name: String): CreateAccessTokenResponse =
@@ -47,8 +46,4 @@ internal abstract class AccessTokenSpecification {
     fun deleteAllTokens() {
         accessTokenFacade.getAccessTokens().forEach { accessTokenFacade.deleteToken(it.identifier) }
     }
-
-    fun workingDirectory(): Path =
-        workingDirectory.toPath()
-
 }

--- a/reposilite-plugins/groovy-plugin/src/main/kotlin/com/reposilite/plugin/groovy/GroovyPlugin.kt
+++ b/reposilite-plugins/groovy-plugin/src/main/kotlin/com/reposilite/plugin/groovy/GroovyPlugin.kt
@@ -20,9 +20,9 @@ import com.reposilite.plugin.PluginLoader
 import com.reposilite.plugin.api.Facade
 import com.reposilite.plugin.api.Plugin
 import com.reposilite.plugin.api.ReposilitePlugin
-import com.reposilite.storage.getSimpleName
 import groovy.lang.GroovyClassLoader
-import java.nio.file.Files
+import kotlin.io.path.extension
+import kotlin.io.path.useDirectoryEntries
 
 @Plugin(name = "groovy")
 class GroovyPlugin : ReposilitePlugin() {
@@ -30,9 +30,9 @@ class GroovyPlugin : ReposilitePlugin() {
     override fun load(loader: PluginLoader) {
         val groovyClassLoader = GroovyClassLoader(this::class.java.classLoader)
 
-        Files.list(loader.pluginsDirectory).use { pluginDirectoryStream ->
+        loader.pluginsDirectory.useDirectoryEntries { pluginDirectoryStream ->
             pluginDirectoryStream
-                .filter { it.getSimpleName().endsWith(".groovy") }
+                .filter { it.extension == "groovy" }
                 .map { groovyClassLoader.parseClass(it.toFile()) }
                 .forEach { extensions().registerPlugin(it.getConstructor().newInstance() as ReposilitePlugin) }
         }

--- a/reposilite-plugins/migration-plugin/src/main/kotlin/com/reposilite/plugin/migration/MigrationPlugin.kt
+++ b/reposilite-plugins/migration-plugin/src/main/kotlin/com/reposilite/plugin/migration/MigrationPlugin.kt
@@ -15,10 +15,10 @@ import com.reposilite.token.Route
 import com.reposilite.token.RoutePermission
 import com.reposilite.token.RoutePermission.READ
 import com.reposilite.token.api.AccessTokenDetails
-import java.nio.file.Files
-import java.nio.file.Path
-import kotlin.io.path.readBytes
 import org.panda_lang.reposilite.auth.TokenCollection
+import java.nio.file.Path
+import kotlin.io.path.notExists
+import kotlin.io.path.readBytes
 
 @Plugin(name = "migration", dependencies = ["maven"])
 class MigrationPlugin : ReposilitePlugin() {
@@ -41,7 +41,7 @@ class MigrationPlugin : ReposilitePlugin() {
     fun migrateTokens(workingDirectory: Path, repositories: Collection<String>): Collection<AccessTokenDetails>? {
         val tokensFile = workingDirectory.resolve("tokens.dat")
 
-        if (Files.notExists(tokensFile)) {
+        if (tokensFile.notExists()) {
             logger.warn("Migration | 'tokens.dat' file not found in working directory, there is nothing that migration plugin can do.")
             return null
         }

--- a/reposilite-plugins/migration-plugin/src/test/kotlin/com/reposilite/plugin/migration/MigrationPluginTest.kt
+++ b/reposilite-plugins/migration-plugin/src/test/kotlin/com/reposilite/plugin/migration/MigrationPluginTest.kt
@@ -7,7 +7,8 @@ import com.reposilite.token.RoutePermission.READ
 import com.reposilite.token.RoutePermission.WRITE
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.nio.file.Files
+import kotlin.io.path.exists
+import kotlin.io.path.writeText
 
 internal class MigrationPluginTest : MigrationPluginSpecification() {
 
@@ -15,7 +16,7 @@ internal class MigrationPluginTest : MigrationPluginSpecification() {
     fun `should migrate old yaml scheme to the new json scheme`() {
         // given: a tokens.dat file and a list of repositories
         val tokensFile = workingDirectory().resolve("tokens.dat")
-        Files.write(tokensFile, resource(test = "should migrate old yaml scheme to the new json scheme", file = "tokens.dat").toByteArray())
+        tokensFile.writeText(resource(test = "should migrate old yaml scheme to the new json scheme", file = "tokens.dat"))
         val repositories = setOf("releases", "snapshots", "private")
 
         // when: migration plugin will proceed migration
@@ -23,7 +24,7 @@ internal class MigrationPluginTest : MigrationPluginSpecification() {
 
         // then: a valid json scheme with up-to-date tokens should be generated
         val schema = workingDirectory().resolve("tokens.json")
-        assertThat(Files.exists(schema)).isTrue
+        assertThat(schema.exists()).isTrue
         assertThat(tokens.size).isEqualTo(3)
 
         val privateToken = tokens.first { it.accessToken.name == "private" }


### PR DESCRIPTION
Cleans up a bunch of random little things, but mainly replaces the use of `Files.*` methods over the kotlin extensions to `Path`

Functionally, absolutely nothing should have changed.