### PR TITLE
Fix invalid link to parameters section in Docker guide

### DIFF
--- a/reposilite-site/data/guides/installation/docker.md
+++ b/reposilite-site/data/guides/installation/docker.md
@@ -59,7 +59,7 @@ $ docker run -e JAVA_OPTS='-Xmx128M' -p 80:8080 dzikoysk/reposilite
 
 #### Reposilite properties
 
-To pass custom parameters described in [setup#parameters](setup#parameters), use `REPOSILITE_OPTS` variable:
+To pass custom parameters described in [general#parameters](general#parameters), use `REPOSILITE_OPTS` variable:
 
 ```bash
 $ docker run -e REPOSILITE_OPTS='--local-configuration=/app/data/custom.cdn' -p 80:8080 dzikoysk/reposilite


### PR DESCRIPTION
Correct the link for "setup#parameters" in https://reposilite.com/guide/docker#reposilite-properties, as it currently directs to `/setup#parameters` instead of the intended `/general#parameters`.