### PR TITLE
Fix Installation link in Footer.js

### DIFF
--- a/reposilite-site/components/layout/Footer.js
+++ b/reposilite-site/components/layout/Footer.js
@@ -8,7 +8,7 @@ const link = (title, url) =>
 
 const guideLinks = [
   link('Getting Started', '/guide/about'),
-  link('Installation', '/guide/standalone'),
+  link('Installation', 'guide/general'),
   link('Plugins', '/plugin'),
   link('Developer API', '/guide/sources'),
 ]


### PR DESCRIPTION
It previously linked to guide/standalone which no longer exists. Changed link to [guide/general](https://reposilite.com/guide/general). Fixes #2283 