### PR TITLE
GH-2282 Add Docker tags for Major and Major.Minor versions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -101,6 +101,15 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: "Generate Docker Tags"
+        id: generate-tags
+        run: |
+          VERSION="${{ needs.github.outputs.version }}"
+          MAJOR=$(echo $VERSION | cut -d '.' -f 1)
+          MINOR=$(echo $VERSION | cut -d '.' -f 2)
+
+          echo "::set-output name=tags::dzikoysk/reposilite:latest,dzikoysk/reposilite:${VERSION},dzikoysk/reposilite:${MAJOR},dzikoysk/reposilite:${MAJOR}.${MINOR},ghcr.io/dzikoysk/reposilite:latest,ghcr.io/dzikoysk/reposilite:${VERSION},ghcr.io/dzikoysk/reposilite:${MAJOR},ghcr.io/dzikoysk/reposilite:${MAJOR}.${MINOR}"
+
       - name: "Build and push"
         id: docker_build
         uses: docker/build-push-action@v3
@@ -108,8 +117,4 @@ jobs:
           context: .
           platforms: "linux/amd64,linux/arm64"
           push: true
-          tags: |
-            dzikoysk/reposilite:latest
-            dzikoysk/reposilite:${{ needs.github.outputs.version }}
-            ghcr.io/dzikoysk/reposilite:latest
-            ghcr.io/dzikoysk/reposilite:${{ needs.github.outputs.version }}
+          tags: ${{ steps.generate-tags.outputs.tags }}


### PR DESCRIPTION
**Purpose**  
This pull request enhances the Docker image tagging process by adding additional tags for `Major` and `Major.Minor` versions alongside the existing `latest` and full release version tags.  

**Why this change?**  
Using only `latest` or the full version (e.g., `3.5.19`) for Docker tags can make managing updates more challenging, especially for users who want to restrict updates to specific major or minor versions. For example:
- A tag like `3.5` allows users to get updates within the `3.5.x` series while avoiding potential changes in version `3.6` without explicit changing the tag.
- Similarly, a `3` tag ensures updates only within the `3.x` series to avoid auto updates with breaking changes.

Adding these tags provides users with more flexibility and control over updates in their environments.

**What was changed?**  
- The `docker` job in the GitHub Actions workflow now generates the following tags for Docker images:
  - `latest`
  - `Major.Minor` (e.g., `3.5`)
  - `Major` (e.g., `3`)
  - Full release version (e.g., `3.5.19`)
- These tags are pushed to both DockerHub and GitHub Container Registry (GHCR).

**How does it work?**  
- A new step (`Generate Docker Tags`) extracts the `Major` and `Minor` parts of the version from `${{ needs.github.outputs.version }}`.
- The generated tags are passed to the `docker/build-push-action`, ensuring all tags are applied to the built image and pushed to the registries.

**Testing**  
While testing was limited due to the lack of actual registry credentials, the logic for tag generation was validated independently to ensure correctness. 

Fixing #2282

It might be possible to update parts of the documentation, but I wasn't sure if and where it would make sense.

Additional notes:
During my tests with GitHub workflows i saw the following warning:
> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I also used `set-output` because it is already used in the workflow.