### PR TITLE
[STEP 2] Migrate Docker images to Alpine and BellSoft Liberica

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Per developer files
+build/
+.idea/
+.gradle/
+.kotlin/
+
+# Dockerfile related files do not need to be included
+Dockerfile
+docker-compose.yml
+.env
+
+# Not used in running application
+reposilite-site
+reposilite-test
+reposilite-plugins
+.github/
+.codecov.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker.io/docker/dockerfile:1.7-labs
 
 # Build stage
-FROM bellsoft/liberica-runtime-container:jdk-21-cds-musl AS build
+FROM bellsoft/liberica-runtime-container:jdk-21-musl AS build
 COPY --exclude=entrypoint.sh . /home/reposilite-build
 WORKDIR /home/reposilite-build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,20 @@
+# syntax=docker.io/docker/dockerfile:1.7-labs
+
 # Build stage
-FROM openjdk:21-slim AS build
-COPY . /home/reposilite-build
+FROM bellsoft/liberica-runtime-container:jdk-21-cds-musl AS build
+COPY --exclude=entrypoint.sh . /home/reposilite-build
 WORKDIR /home/reposilite-build
-RUN \
-  rm -rf reposilite-frontend/node_modules
-RUN \
-  apt-get update; apt-get install -y curl
-RUN \
-  export GRADLE_OPTS="-Djdk.lang.Process.launchMechanism=vfork" && \
-  chmod +x gradlew && \
-  bash gradlew :reposilite-backend:shadowJar --no-daemon --stacktrace
+
+# Get build dependencies seperately so they can cache
+RUN <<EOF
+   apk --no-cache add nodejs
+EOF
+
+# The below line will show an Error in some IDE's, It is valid Dockerfile.
+RUN --mount=type=cache,target=/root/.gradle <<EOF
+  export GRADLE_OPTS="-Djdk.lang.Process.launchMechanism=vfork"
+  ./gradlew :reposilite-backend:shadowJar --no-daemon --stacktrace
+EOF
 
 # Build-time metadata stage
 ARG BUILD_DATE
@@ -25,15 +30,36 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.version=$VERSION \
       org.label-schema.schema-version="1.0"
 
+
 # Run stage
-FROM openjdk:21-slim
-RUN mkdir -p /app/data && mkdir -p /var/log/reposilite
+FROM bellsoft/liberica-runtime-container:jre-21-slim-musl AS run
+
+# Run everything at the lowest possible permissions
+ARG PGID="977"
+ARG PUID="977"
+
 VOLUME /app/data
+
+RUN <<EOF
+    mkdir -p /app/data
+    mkdir -p /var/log/reposilite
+    addgroup -Sg "$PGID" reposilite
+
+    adduser -SH \
+    -h /app \
+    -s "/usr/sbin/nologin" \
+    -G reposilite \
+    -u "$PUID" reposilite
+EOF
+
 WORKDIR /app
 COPY --from=build /home/reposilite-build/reposilite-backend/build/libs/reposilite-3*.jar reposilite.jar
-COPY --from=build /home/reposilite-build/entrypoint.sh entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
-RUN apt-get update && apt-get -y install util-linux curl
+COPY --chmod=755 entrypoint.sh entrypoint.sh
+RUN <<EOF
+    chown -R "$PUID:$PGID" /app /var/log/reposilite
+EOF
+USER reposilite
+
 HEALTHCHECK --interval=30s --timeout=30s --start-period=15s \
     --retries=3 CMD [ "sh", "-c", "URL=$(cat /app/data/.local/reposilite.address); echo -n \"curl $URL... \"; \
     (\

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,6 @@ RUN <<EOF
     mkdir -p /app/data
     mkdir -p /var/log/reposilite
     addgroup -Sg "$PGID" reposilite
-
     adduser -SH \
     -h /app \
     -s "/usr/sbin/nologin" \
@@ -68,5 +67,4 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=15s \
         echo Fail && exit 2\
     )"]
 ENTRYPOINT ["/app/entrypoint.sh"]
-CMD []
 EXPOSE 8080

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
-
+#!/usr/bin/env sh
 # shellcheck disable=SC2086
+
 set -e
 
 REPOSILITE_ARGS="$REPOSILITE_OPTS"
@@ -10,36 +10,14 @@ case "$REPOSILITE_OPTS" in
   *                      ) REPOSILITE_ARGS="--working-directory=/app/data $REPOSILITE_ARGS";;
 esac
 
-# GH-1762: support for running as non-root user
-if (($(id -u) != 0)); then
-  exec java \
-       -Dtinylog.writerFile.file="/var/log/reposilite/log_{date}.txt" \
-       -Dtinylog.writerFile.latest=/var/log/reposilite/latest.log \
-       $JAVA_OPTS \
-       -jar reposilite.jar \
-       $REPOSILITE_ARGS
-# GH-1200: run as non-root user
-else
-  # GH-1634: support custom user and group ids
-  GROUP_ID="${PGID:-999}"
-  if ! grep -q "^reposilite" /etc/group;
-  then
-    addgroup --gid "$GROUP_ID" reposilite;
-  fi
-  USER_ID="${PUID:-999}"
-  if ! grep "^reposilite" /etc/passwd;
-  then
-    adduser --system -uid "$USER_ID" --ingroup reposilite --shell /bin/sh reposilite;
-  fi
-
-  chown -R reposilite:reposilite /app
-  chown -R reposilite:reposilite /var/log/reposilite
-
-  exec runuser -u reposilite -- \
-    java \
-       -Dtinylog.writerFile.file="/var/log/reposilite/log_{date}.txt" \
-       -Dtinylog.writerFile.latest=/var/log/reposilite/latest.log \
-       $JAVA_OPTS \
-       -jar reposilite.jar \
-       $REPOSILITE_ARGS
+if [ "$(id -u)" = 0 ] ; then
+  echo "This script should only be run as a non-root user, preferably in a docker container"
+  return 1
 fi
+
+exec java \
+     -Dtinylog.writerFile.file="/var/log/reposilite/log_{date}.txt" \
+     -Dtinylog.writerFile.latest=/var/log/reposilite/latest.log \
+     $JAVA_OPTS \
+     -jar reposilite.jar \
+     $REPOSILITE_ARGS


### PR DESCRIPTION
- Default user and group id is now 977 as 999 was taken.
> [!CAUTION]
> **!!This may cause permissions issues in existing installations**. 
> The above mentioned permissions issues can be fixed by either:
> - mounting the volume with another container as a root user and changing ownership of `/app/data` (including their contents) to 977:977
> - `chown -R 977:977 /var/lib/docker/volumes/${VOLUME_NAME_OR_HASH}` of the volume from the host's volume directory.
> - `chmod -R  777 /app/data` (don't do this)
- Dockerfile and entrypoint.sh was changed to run NO application code as a privileged user. When the container is running there is no code executed in a privileged context, as anything requiring privileges is run during build time. 
- Addition of a .dockerignore file to ignore non-application files and improve docker cache hits.

Proposed fix #2288




