### PR TITLE
GH-2288 Migrate Docker images to Ubuntu and Eclipse Temurin and change user/group id

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Per developer files
+build/
+.idea/
+.gradle/
+.kotlin/
+
+# Dockerfile related files do not need to be included
+Dockerfile
+docker-compose.yml
+.env
+
+# Not used in running application
+reposilite-site
+reposilite-test
+reposilite-plugins
+.github/
+.codecov.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
+# syntax=docker.io/docker/dockerfile:1.7-labs
+
 # Build stage
-FROM openjdk:21-slim AS build
-COPY . /home/reposilite-build
+FROM eclipse-temurin:21-jdk-noble AS build
+COPY --exclude=entrypoint.sh . /home/reposilite-build
 WORKDIR /home/reposilite-build
-RUN \
-  rm -rf reposilite-frontend/node_modules
-RUN \
-  apt-get update; apt-get install -y curl
-RUN \
-  export GRADLE_OPTS="-Djdk.lang.Process.launchMechanism=vfork" && \
-  chmod +x gradlew && \
-  bash gradlew :reposilite-backend:shadowJar --no-daemon --stacktrace
+
+# The below line will show an Error in some IDE's, It is valid Dockerfile.
+RUN --mount=type=cache,target=/root/.gradle <<EOF
+  export GRADLE_OPTS="-Djdk.lang.Process.launchMechanism=vfork"
+  ./gradlew :reposilite-backend:shadowJar --no-daemon --stacktrace
+EOF
 
 # Build-time metadata stage
 ARG BUILD_DATE
@@ -26,14 +26,21 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.schema-version="1.0"
 
 # Run stage
-FROM openjdk:21-slim
+FROM eclipse-temurin:21-jre-noble AS run
+
+# Setup runtime environment
 RUN mkdir -p /app/data && mkdir -p /var/log/reposilite
 VOLUME /app/data
+RUN <<EOF
+    mkdir -p /app/data
+    mkdir -p /var/log/reposilite
+EOF
 WORKDIR /app
+
+# Import application code
+COPY --chmod=755 entrypoint.sh entrypoint.sh
 COPY --from=build /home/reposilite-build/reposilite-backend/build/libs/reposilite-3*.jar reposilite.jar
-COPY --from=build /home/reposilite-build/entrypoint.sh entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
-RUN apt-get update && apt-get -y install util-linux curl
+
 HEALTHCHECK --interval=30s --timeout=30s --start-period=15s \
     --retries=3 CMD [ "sh", "-c", "URL=$(cat /app/data/.local/reposilite.address); echo -n \"curl $URL... \"; \
     (\
@@ -42,5 +49,4 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=15s \
         echo Fail && exit 2\
     )"]
 ENTRYPOINT ["/app/entrypoint.sh"]
-CMD []
 EXPOSE 8080

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # shellcheck disable=SC2086
 set -e
@@ -11,7 +11,8 @@ case "$REPOSILITE_OPTS" in
 esac
 
 # GH-1762: support for running as non-root user
-if (($(id -u) != 0)); then
+
+if [ "$(id -u)" != 0 ]; then
   exec java \
        -Dtinylog.writerFile.file="/var/log/reposilite/log_{date}.txt" \
        -Dtinylog.writerFile.latest=/var/log/reposilite/latest.log \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,13 +21,26 @@ if [ "$(id -u)" != 0 ]; then
        $REPOSILITE_ARGS
 # GH-1200: run as non-root user
 else
+
+  # GH-2288: Dockerfile Step-1 migration warning
+  # shellcheck disable=SC2012
+  existing_uid=$(ls -dln data | awk '{print $3}')
+  # shellcheck disable=SC2012
+  existing_gid=$(ls -dln data | awk '{print $4}')
+  if [ $existing_uid != "977" ]||[ $existing_gid != "977" ]; then
+    printf "\033[1;31mStarting with Reposilite 3.5.20 the standard user id will be 977, I will make those changes now.\033[0m\n" 1>&2
+    printf "\033[1;31mAfter 3.6.0 docker installations with user id of 999 will no longer work.\033[0m\n" 1>&2
+    printf "\033[1;31mFor more information see: https://github.com/dzikoysk/reposilite/issues/2288\033[0m\n" 1>&2
+    printf "\033[1;31mIF YOU DOWNGRADE PAST THIS POINT \"Hic sunt dracones\"\033[0m\n" 1>&2
+  fi
+
   # GH-1634: support custom user and group ids
-  GROUP_ID="${PGID:-999}"
+  GROUP_ID="${PGID:-977}"
   if ! grep -q "^reposilite" /etc/group;
   then
     addgroup --gid "$GROUP_ID" reposilite;
   fi
-  USER_ID="${PUID:-999}"
+  USER_ID="${PUID:-977}"
   if ! grep "^reposilite" /etc/passwd;
   then
     adduser --system -uid "$USER_ID" --ingroup reposilite --shell /bin/sh reposilite;


### PR DESCRIPTION
[As per discussed in #2289](https://github.com/dzikoysk/reposilite/pull/2289#issuecomment-2508117580)
- Update entrypoint.sh to be POSIX compatible (formerly used some BASH only syntax) for eventual switch to an Alpine Image.
- Update entrypoint.sh to include a warning about backwards compatibility and the changes coming to docker images with 3.6.X. Script will automatically change permissions of directories that require update.
- Use `eclipse-temurin:21-XXX-noble` images for build and run stages of Dockerfile.
- Speed up build time for local builds of Reposilite images by
  - Changing the ordering of Dockerfile instructions to allow for more parallel building and increased cache hits
  - Include an .dockerignore file to exclude most non-application files.