### PR TITLE
Add "reposilite.s3.use-s3-v4-signer" property to use the S3V4 signer

### DIFF
--- a/reposilite-backend/src/main/kotlin/com/reposilite/storage/s3/S3StorageProviderFactory.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/storage/s3/S3StorageProviderFactory.kt
@@ -21,12 +21,16 @@ import com.reposilite.status.FailureFacade
 import com.reposilite.storage.StorageProviderFactory
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.auth.signer.AwsS3V4Signer
+import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.S3Configuration
 import java.net.URI
 import java.nio.file.Path
 import java.time.Duration
+
+private val useS3V4Signer = System.getProperty("reposilite.s3.use-s3-v4-signer", "false") == "true"
 
 class S3StorageProviderFactory : StorageProviderFactory<S3StorageProvider, S3StorageProviderSettings> {
 
@@ -75,6 +79,10 @@ class S3StorageProviderFactory : StorageProviderFactory<S3StorageProvider, S3Sto
             it.retryPolicy { cfg ->
                 cfg.backoffStrategy(ExponentialBackoffStrategy(Duration.ofSeconds(1), Duration.ofMinutes(1)))
                 cfg.numRetries(5)
+            }
+
+            if (useS3V4Signer) {
+                it.putAdvancedOption(SdkAdvancedClientOption.SIGNER, AwsS3V4Signer.create())
             }
         }
 


### PR DESCRIPTION
Some S3-compatible providers (like Cloudflare R2) require S3V4-specific signing, otherwise resulting in errors such as:
```
06:29:03.062 ERROR | software.amazon.awssdk.services.s3.model.S3Exception: The request signature we calculated does not match the signature you provided. Check your secret access key and signing method. (Service: S3, Status Code: 403, Request ID: null)
06:29:03.062 ERROR |    at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handleErrorResponse(AwsXmlPredicatedResponseHandler.java:155)
06:29:03.062 ERROR |    at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handleResponse(AwsXmlPredicatedResponseHandler.java:107)
06:29:03.062 ERROR |    at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handle(AwsXmlPredicatedResponseHandler.java:84)
06:29:03.062 ERROR |    at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handle(AwsXmlPredicatedResponseHandler.java:42)
06:29:03.062 ERROR |    at software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler$Crc32ValidationResponseHandler.handle(AwsSyncClientHandler.java:93)
06:29:03.062 ERROR |    at software.amazon.awssdk.core.internal.handler.BaseClientHandler.lambda$successTransformationResponseHandler$7(BaseClientHandler.java:279)
06:29:03.062 ERROR |    at software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.execute(HandleResponseStage.java:50)
06:29:03.062 ERROR |    at software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.execute(HandleResponseStage.java:38)
06:29:03.062 ERROR |    at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
06:29:03.062 ERROR |    at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:74)
06:29:03.062 ERROR |    at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:43)
06:29:03.062 ERROR |    at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:79)
06:29:03.062 ERROR |    at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:41)
06:29:03.062 ERROR |    at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptMetricCollectionStage.execute(ApiCallAttemptMetricCollectionStage.java:55)
06:29:03.063 ERROR |    at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptMetricCollectionStage.execute(ApiCallAttemptMetricCollectionStage.java:39)
06:29:03.063 ERROR |    at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.executeRequest(RetryableStage.java:93)
06:29:03.063 ERROR |    at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:56)
06:29:03.063 ERROR |    at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:36)
06:29:03.063 ERROR |    at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
06:29:03.063 ERROR |    at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:53)
06:29:03.063 ERROR |    at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:35)
06:29:03.063 ERROR |    at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.executeWithTimer(ApiCallTimeoutTrackingStage.java:82)
06:29:03.063 ERROR |    at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:62)
06:29:03.063 ERROR |    at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:43)
06:29:03.063 ERROR |    at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallMetricCollectionStage.execute(ApiCallMetricCollectionStage.java:50)
06:29:03.063 ERROR |    at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallMetricCollectionStage.execute(ApiCallMetricCollectionStage.java:32)
06:29:03.063 ERROR |    at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
06:29:03.063 ERROR |    at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
06:29:03.063 ERROR |    at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:37)
06:29:03.063 ERROR |    at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:26)
06:29:03.063 ERROR |    at software.amazon.awssdk.core.internal.http.AmazonSyncHttpClient$RequestExecutionBuilderImpl.execute(AmazonSyncHttpClient.java:210)
06:29:03.063 ERROR |    at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.invoke(BaseSyncClientHandler.java:103)
06:29:03.063 ERROR |    at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.doExecute(BaseSyncClientHandler.java:173)
06:29:03.064 ERROR |    at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.lambda$execute$1(BaseSyncClientHandler.java:80)
06:29:03.064 ERROR |    at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.measureApiCallSuccess(BaseSyncClientHandler.java:182)
06:29:03.064 ERROR |    at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.execute(BaseSyncClientHandler.java:74)
06:29:03.064 ERROR |    at software.amazon.awssdk.core.client.handler.SdkSyncClientHandler.execute(SdkSyncClientHandler.java:45)
06:29:03.064 ERROR |    at software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler.execute(AwsSyncClientHandler.java:53)
06:29:03.064 ERROR |    at software.amazon.awssdk.services.s3.DefaultS3Client.putObject(DefaultS3Client.java:11202)
06:29:03.064 ERROR |    at com.reposilite.storage.s3.S3StorageProvider.putFile(S3StorageProvider.kt:113)
06:29:03.064 ERROR |    at com.reposilite.maven.MirrorService.storeFile(MirrorService.kt:69)
06:29:03.064 ERROR |    at com.reposilite.maven.MirrorService.access$storeFile(MirrorService.kt:37)
06:29:03.064 ERROR |    at com.reposilite.maven.MirrorService$findRemoteFile$1.invoke$lambda$0(MirrorService.kt:63)
06:29:03.064 ERROR |    at panda.std.Result.flatMap(Result.java:170)
06:29:03.064 ERROR |    at com.reposilite.maven.MirrorService$findRemoteFile$1.invoke(MirrorService.kt:63)
06:29:03.064 ERROR |    at com.reposilite.maven.MirrorService$findRemoteFile$1.invoke(MirrorService.kt:61)
06:29:03.064 ERROR |    at com.reposilite.maven.MirrorService$searchInRemoteRepositories$2.invoke(MirrorService.kt:83)
06:29:03.064 ERROR |    at com.reposilite.maven.MirrorService$searchInRemoteRepositories$2.invoke(MirrorService.kt:83)
06:29:03.064 ERROR |    at kotlin.sequences.TransformingSequence$iterator$1.next(Sequences.kt:210)
06:29:03.064 ERROR |    at com.reposilite.maven.MirrorService.searchInRemoteRepositories(MirrorService.kt:114)
06:29:03.064 ERROR |    at com.reposilite.maven.MirrorService.findRemoteFile(MirrorService.kt:61)
06:29:03.064 ERROR |    at com.reposilite.maven.RepositoryService.findInputStream(RepositoryService.kt:162)
06:29:03.064 ERROR |    at com.reposilite.maven.RepositoryService.access$findInputStream(RepositoryService.kt:49)
06:29:03.064 ERROR |    at com.reposilite.maven.RepositoryService$findInputStream$1.invoke(RepositoryService.kt:146)
06:29:03.064 ERROR |    at com.reposilite.maven.RepositoryService$findInputStream$1.invoke(RepositoryService.kt:146)
06:29:03.064 ERROR |    at com.reposilite.maven.RepositoryService.resolve$lambda$10(RepositoryService.kt:132)
06:29:03.065 ERROR |    at panda.std.Result.flatMap(Result.java:170)
06:29:03.065 ERROR |    at com.reposilite.maven.RepositoryService.resolve(RepositoryService.kt:132)
06:29:03.065 ERROR |    at com.reposilite.maven.RepositoryService.findInputStream(RepositoryService.kt:146)
06:29:03.065 ERROR |    at com.reposilite.maven.MavenFacade.findData(MavenFacade.kt:59)
06:29:03.065 ERROR |    at com.reposilite.maven.infrastructure.MavenEndpoints$findFile$2$1.invoke(MavenEndpoints.kt:87)
06:29:03.065 ERROR |    at com.reposilite.maven.infrastructure.MavenEndpoints$findFile$2$1.invoke(MavenEndpoints.kt:83)
06:29:03.065 ERROR |    at com.reposilite.maven.infrastructure.MavenEndpoints.findFile$lambda$2$lambda$0(MavenEndpoints.kt:83)
06:29:03.065 ERROR |    at panda.std.Result.map(Result.java:152)
06:29:03.065 ERROR |    at com.reposilite.maven.infrastructure.MavenEndpoints.findFile(MavenEndpoints.kt:83)
06:29:03.065 ERROR |    at com.reposilite.maven.infrastructure.MavenEndpoints$findFile$1$1$1.invoke(MavenEndpoints.kt:74)
06:29:03.065 ERROR |    at com.reposilite.maven.infrastructure.MavenEndpoints$findFile$1$1$1.invoke(MavenEndpoints.kt:73)
06:29:03.065 ERROR |    at com.reposilite.maven.infrastructure.MavenRoutes.requireGav(MavenRoutes.kt:48)
06:29:03.065 ERROR |    at com.reposilite.maven.infrastructure.MavenEndpoints$findFile$1$1.invoke(MavenEndpoints.kt:73)
06:29:03.065 ERROR |    at com.reposilite.maven.infrastructure.MavenEndpoints$findFile$1$1.invoke(MavenEndpoints.kt:72)
06:29:03.065 ERROR |    at com.reposilite.shared.ContextDsl.accessed(ContextDsl.kt:60)
06:29:03.065 ERROR |    at com.reposilite.maven.infrastructure.MavenEndpoints$findFile$1.invoke(MavenEndpoints.kt:72)
06:29:03.065 ERROR |    at com.reposilite.maven.infrastructure.MavenEndpoints$findFile$1.invoke(MavenEndpoints.kt:71)
06:29:03.065 ERROR |    at com.reposilite.web.infrastructure.ReposiliteRoutingKt$createReposiliteDsl$dsl$1.invoke$lambda$0(ReposiliteRouting.kt:78)
06:29:03.065 ERROR |    at io.javalin.router.Endpoint.handle(Endpoint.kt:52)
06:29:03.065 ERROR |    at io.javalin.router.ParsedEndpoint.handle(ParsedEndpoint.kt:15)
06:29:03.065 ERROR |    at io.javalin.http.servlet.DefaultTasks.HTTP$lambda$9$lambda$7$lambda$6(DefaultTasks.kt:52)
06:29:03.065 ERROR |    at io.javalin.http.servlet.JavalinServlet.handleTask(JavalinServlet.kt:99)
06:29:03.065 ERROR |    at io.javalin.http.servlet.JavalinServlet.handleSync(JavalinServlet.kt:64)
06:29:03.065 ERROR |    at io.javalin.http.servlet.JavalinServlet.handle(JavalinServlet.kt:50)
06:29:03.065 ERROR |    at io.javalin.http.servlet.JavalinServlet.service(JavalinServlet.kt:30)
06:29:03.065 ERROR |    at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:587)
06:29:03.065 ERROR |    at io.javalin.jetty.JavalinJettyServlet.service(JavalinJettyServlet.kt:52)
06:29:03.065 ERROR |    at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:587)
06:29:03.065 ERROR |    at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:764)
06:29:03.065 ERROR |    at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:529)
06:29:03.066 ERROR |    at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:221)
06:29:03.066 ERROR |    at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1580)
06:29:03.066 ERROR |    at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:221)
06:29:03.066 ERROR |    at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1381)
06:29:03.066 ERROR |    at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:176)
06:29:03.066 ERROR |    at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:484)
06:29:03.066 ERROR |    at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1553)
06:29:03.066 ERROR |    at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:174)
06:29:03.066 ERROR |    at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1303)
06:29:03.066 ERROR |    at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:129)
06:29:03.066 ERROR |    at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:122)
06:29:03.066 ERROR |    at org.eclipse.jetty.server.Server.handle(Server.java:563)
06:29:03.066 ERROR |    at org.eclipse.jetty.server.HttpChannel$RequestDispatchable.dispatch(HttpChannel.java:1598)
06:29:03.066 ERROR |    at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:753)
06:29:03.066 ERROR |    at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:501)
06:29:03.066 ERROR |    at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:287)
06:29:03.066 ERROR |    at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:314)
06:29:03.066 ERROR |    at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:100)
06:29:03.066 ERROR |    at org.eclipse.jetty.io.SelectableChannelEndPoint$1.run(SelectableChannelEndPoint.java:53)
06:29:03.066 ERROR |    at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.runTask(AdaptiveExecutionStrategy.java:421)
06:29:03.066 ERROR |    at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.consumeTask(AdaptiveExecutionStrategy.java:390)
06:29:03.066 ERROR |    at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.tryProduce(AdaptiveExecutionStrategy.java:277)
06:29:03.066 ERROR |    at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.run(AdaptiveExecutionStrategy.java:199)
06:29:03.066 ERROR |    at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:411)
06:29:03.066 ERROR |    at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:969)
06:29:03.066 ERROR |    at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.doRunJob(QueuedThreadPool.java:1194)
06:29:03.066 ERROR |    at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1149)
06:29:03.066 ERROR |    at java.base/java.lang.Thread.run(Unknown Source)
06:29:03.066 ERROR |
```