### PR TITLE
Implement authenticated only fetching of uncached mirror artifacts

### DIFF
--- a/reposilite-backend/src/main/kotlin/com/reposilite/maven/application/MavenSettings.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/maven/application/MavenSettings.kt
@@ -98,7 +98,13 @@ data class MirroredRepositorySettings(
         HTTP 127.0.0.1:1081 <br/>
         SOCKS 127.0.0.1:1080 login password 
     """)
-    val httpProxy: String = ""
+    val httpProxy: String = "",
+    @get:Doc(title = "Authenticated Fetching Only", description = """
+        Whether to require an authenticated connection before fetching uncached artifacts from the remote repository.<br/>
+        _This should only ever be turned on in conjunction with the store option or with a secondary mirror host that has this option turned off.<br/>
+        If you are looking to hide this mirror from unauthenticated connections, please use repository visibility options instead._
+    """)
+    val authenticatedFetchingOnly: Boolean = false
 ) : SharedSettings
 
 @Doc(title = "Mirror Credentials", description = "The authorization credentials used to access mirrored repository.")


### PR DESCRIPTION
Implements #2369 

This adds a new option to the maven mirrored repo settings that filters it out from the possible source of mirrors when there is no authenticated user in the request. Ideally this should only ever be used with the caching system turned on or another mirror host that has this option turned as otherwise this will deny/hide what used to be valid request.