### PR TITLE
Added List of available javadocs  to JavadocView

### DIFF
--- a/reposilite-backend/src/main/kotlin/com/reposilite/javadocs/application/JavadocPlugin.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/javadocs/application/JavadocPlugin.kt
@@ -56,11 +56,11 @@ internal class JavadocPlugin : ReposilitePlugin() {
                 .takeIf { it.toString().endsWith("-javadoc.jar") }
                 ?: return@event
 
-            val container = javadocContainerService.createContainer(javadocFolder, event.repository, gav)
-            val javadocDirectory = container.javadocContainerPath.toFile()
+            val artifactRootContainer = javadocContainerService.createContainer(javadocFolder, event.repository, gav.getParent())
+            val artifactRootDirectory = artifactRootContainer.javadocContainerPath.toFile().parentFile
 
-            if (javadocDirectory.exists()) {
-                javadocDirectory.deleteRecursively()
+            if (artifactRootDirectory.exists()) {
+                artifactRootDirectory.deleteRecursively()
             }
         }
 


### PR DESCRIPTION
**Implementation Details**
**Generate Javadoc List:**
-     Retrieved all files within the artifact and filtered for directories that contain a *-javadoc.jar file.
-     Created a list of FileDetails from the filtered results.
-     Passed this list to JavadocView, which renders a dropdown menu in the top navigation bar next to Raw Docs.
**Validate Javadoc Cache:**
Since Javadocs are cached after extraction, I implemented cache invalidation by deleting the entire Javadoc cache directory for the artifact whenever a new *-javadoc.jar is uploaded.