### PR TITLE
GH-2420 Add repository to javadoc example path in docs

### DIFF
--- a/reposilite-site/data/guides/features/javadocs.md
+++ b/reposilite-site/data/guides/features/javadocs.md
@@ -6,7 +6,7 @@ title: Javadocs
 Host JavaDoc pages automatically using JAR files (`*-javadoc.jar`) located in repositories.
 Javadoc file is extracted during the first request to `$working-directory/javadocs` directory.
 
-To access javadocs, you have to visit `repo.domain.com/javadoc/<gav>`. 
+To access javadocs, you have to visit `repo.domain.com/javadoc/<repository>/<gav>`. 
 For instance, using Reposilite Javadocs:
 
 * [reposilite repository / reposilite-3.0.2 javadocs](https://maven.reposilite.com/javadoc/releases/com/reposilite/reposilite/3.0.2/)


### PR DESCRIPTION
I added the missing <repository> part to example javadoc path.