### PR TITLE
docs: fix hyperlink that broke with commit

### DIFF
--- a/reposilite-site/data/guides/migration/artifactory.md
+++ b/reposilite-site/data/guides/migration/artifactory.md
@@ -8,7 +8,7 @@ title: Artifactory
 Reposilite works slightly different than Artifactory or Nexus, so make sure you've properly configured your instance and environment.
 Guides you may find especially useful during migration:
 
-* [Reposilite / Guide - Settings](/guide/settings) - How you can configure Reposilite instance
+* [Reposilite / Guide - General](/guide/general) - How you can configure Reposilite instance
 * [Reposilite / Guide - Tokens](/guide/tokens) - How to generate access to your instance
 
 ### Export repository from Artifactory


### PR DESCRIPTION
* broken in 813c6f6c9cce8945471c76a2805f41ff60085fd1
* file renamed from settings to general
* commit directs the hyperlink to the new page location