### PR TITLE
GH-2462 docker-compose: left behind on 3.2.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,7 @@ scmVersion {
         fileUpdate(".github/README.md") { version -> "reposilite-$version.jar" }
         fileUpdate(".github/README.md") { version -> "dzikoysk/reposilite:$version" }
         fileUpdate("docker-compose.yml") { version -> "image: reposilite:$version" }
+        fileUpdate("docker-compose.yml") { version -> "image: dzikoysk/reposilite:$version" }
         fileUpdate("reposilite-backend/src/main/kotlin/com/reposilite/Reposilite.kt") { version -> "const val VERSION = \"$version\"" }
         fileUpdate("reposilite-frontend/package.json") { version -> "\"version\": \"$version\"" }
         fileUpdate("reposilite-frontend/package-lock.json") { version -> "\"version\": \"$version\"" }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   reposilite:
-    image: dzikoysk/reposilite:3.2.0
+    image: dzikoysk/reposilite:3.5.25
     #
     # To build from sources:
     #


### PR DESCRIPTION
* gradle build was updated commented out line for building from source
* update action to update actual image line and bump docker-compose to 3.5.25