### PR TITLE
GH-2581 Allow disabling sorting for latest version endpoint

### DIFF
--- a/reposilite-backend/src/main/kotlin/com/reposilite/maven/MavenFacade.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/maven/MavenFacade.kt
@@ -79,7 +79,7 @@ class MavenFacade internal constructor(
 
     fun findLatestVersion(lookupRequest: VersionLookupRequest): Result<LatestVersionResponse, ErrorResponse> =
         repositorySecurityProvider.canAccessResource(lookupRequest.accessToken, lookupRequest.repository, lookupRequest.gav)
-            .flatMap { metadataService.findLatestVersion(lookupRequest.repository, lookupRequest.gav, lookupRequest.filter) }
+            .flatMap { metadataService.findLatestVersion(lookupRequest.repository, lookupRequest.gav, lookupRequest.filter, lookupRequest.sorted) }
 
     fun <T> findLatestVersionFile(latestArtifactQueryRequest: LatestArtifactQueryRequest, handler: MatchedVersionHandler<T>): Result<T, ErrorResponse> =
         latestService.queryLatestArtifact(

--- a/reposilite-backend/src/main/kotlin/com/reposilite/maven/MetadataService.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/maven/MetadataService.kt
@@ -154,8 +154,8 @@ internal class MetadataService(private val repositorySecurityProvider: Repositor
             else -> ({ it.startsWith(filter) })
         }
 
-    fun findLatestVersion(repository: Repository, gav: Location, filter: String?): Result<LatestVersionResponse, ErrorResponse> =
-        findVersions(repository, gav, filter)
+    fun findLatestVersion(repository: Repository, gav: Location, filter: String?, sorted: Boolean = true): Result<LatestVersionResponse, ErrorResponse> =
+        findVersions(repository, gav, filter, sorted)
             .filter({ it.versions.isNotEmpty() }, { notFound("Given artifact does not have any declared version") })
             .map { (isSnapshot, versions) -> LatestVersionResponse(isSnapshot, versions.last()) }
 

--- a/reposilite-backend/src/main/kotlin/com/reposilite/maven/infrastructure/MavenLatestApiEndpoints.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/maven/infrastructure/MavenLatestApiEndpoints.kt
@@ -61,6 +61,7 @@ internal class MavenLatestApiEndpoints(
             OpenApiParam(name = "classifier", description = "Appends classifier suffix to matched file", required = false),
             OpenApiParam(name = "filter", description = "Version (prefix) filter to apply", required = false),
             OpenApiParam(name = "type", description = "Format of expected response type: empty (default) for json; 'raw' for plain text", required = false),
+            OpenApiParam(name = "sorted", description = "Whether to sort versions using built-in comparator (default: true). Set to false to preserve raw order from maven-metadata.xml", required = false),
         ],
         responses = [
             OpenApiResponse("200", content = [OpenApiContent(from = LatestVersionResponse::class)], description = "default response"),
@@ -71,7 +72,7 @@ internal class MavenLatestApiEndpoints(
         accessed {
             requireGav { gav ->
                 requireRepository { repository ->
-                    response = VersionLookupRequest(this?.identifier, repository, gav, ctx.queryParam("filter"))
+                    response = VersionLookupRequest(this?.identifier, repository, gav, ctx.queryParam("filter"), ctx.queryParam("sorted")?.toBooleanStrictOrNull() ?: true)
                         .let { mavenFacade.findLatestVersion(it) }
                         .flatMap {
                             when (val type = ctx.queryParam("type")) {

--- a/reposilite-backend/src/test/kotlin/com/reposilite/maven/MavenFacadeTest.kt
+++ b/reposilite-backend/src/test/kotlin/com/reposilite/maven/MavenFacadeTest.kt
@@ -395,6 +395,19 @@ internal class MavenFacadeTest : MavenSpecification() {
         }
 
         @Test
+        fun `should preserve raw metadata order for latest version when sorted is false`() {
+            // given: an artifact with metadata file containing versions in specific order
+            val rawOrder = listOf("1.21-20240613.152323", "1.21.2-20241022.151510", "1.20.6-20240627.102356")
+            val (repository, artifact) = useMetadata(PUBLIC.name, "/unsorted", rawOrder)
+
+            // when: latest version is requested with sorted=false
+            val response = mavenFacade.findLatestVersion(VersionLookupRequest(UNAUTHORIZED, repository, artifact, filter = null, sorted = false))
+
+            // then: should preserve the original order from maven-metadata.xml
+            assertOk(rawOrder.last(), response.map { it.version })
+        }
+
+        @Test
         fun `should sort versions by default`() {
             // given: an artifact with metadata file containing unordered versions
             val versions = listOf("2.0.0", "1.0.0", "1.1.0")


### PR DESCRIPTION
This PR resolves #2581 by implementing a `sorted` query parameter for the `/latest/version` Maven repository API endpoint.

Implemented in a similar fashion to #2573, and the test works as expected.