### PR TITLE
feat: Add support for legal notice in footer

### DIFF
--- a/reposilite-backend/src/main/kotlin/com/reposilite/frontend/FrontendFacade.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/frontend/FrontendFacade.kt
@@ -67,6 +67,7 @@ class FrontendFacade internal constructor(
                 "{{REPOSILITE.ORGANIZATION_LOGO}}" to organizationLogo,
                 "{{REPOSILITE.ICP_LICENSE}}" to icpLicense,
                 "{{REPOSILITE.PRIVACY_POLICY}}" to privacyPolicy,
+                "{{REPOSILITE.LEGAL_NOTICE}}" to legalNotice,
             ))
         }
 

--- a/reposilite-backend/src/main/kotlin/com/reposilite/frontend/application/FrontendSettings.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/frontend/application/FrontendSettings.kt
@@ -41,6 +41,8 @@ data class FrontendSettings(
     val organizationLogo: String = "https://avatars.githubusercontent.com/u/88636591",
     @get:Doc(title = "Privacy Policy", description = "Link to your privacy policy displayed in the footer. Useful for EU GDPR compliance.")
     val privacyPolicy: String = "",
+    @get:Doc(title = "Legal Notice", description = "Link to your legal notice displayed in the footer. Useful for local law compliance.")
+    val legalNotice: String = "",
     @get:Doc(title = "ICP License", description = """
         Web services in China require ICP license, a permit issued by the Chinese government to permit China-based websites to operate in China.
         In order to fulfill the conditions, you should apply for ICP license from your service provider and fill in this parameter.

--- a/reposilite-frontend/src/App.vue
+++ b/reposilite-frontend/src/App.vue
@@ -21,7 +21,7 @@ import useTheme from "./store/theme"
 import useQualifier from "./store/qualifier"
 import usePlaceholders from './store/placeholders'
 
-const { title, description, icpLicense, privacyPolicy } = usePlaceholders()
+const { title, description, icpLicense, privacyPolicy, legalNotice } = usePlaceholders()
 const { theme, fetchColorMode } = useTheme()
 const { initializeSession } = useSession()
 const { qualifier } = useQualifier()
@@ -41,10 +41,12 @@ initializeSession().catch(() => {})
         class="router-view-full "
         :qualifier="qualifier"
       />
-      <div v-if="icpLicense || privacyPolicy" class="absolute h-8 pb-2 w-full text-center text-xs dark:bg-black dark:text-white">
+      <div v-if="icpLicense || privacyPolicy || legalNotice" class="absolute h-8 pb-2 w-full text-center text-xs dark:bg-black dark:text-white">
         <a v-if="icpLicense" href="https://beian.miit.gov.cn" target="_blank">{{ icpLicense }}</a>
         <span v-if="icpLicense && privacyPolicy" class="mx-1">·</span>
         <a v-if="privacyPolicy" :href="privacyPolicy" target="_blank">Privacy Policy</a>
+        <span v-if="(icpLicense || privacyPolicy) && legalNotice" class="mx-1">·</span>
+        <a v-if="legalNotice" :href="legalNotice" target="_blank">Legal Notice</a>
       </div>
     </div>
   </div>

--- a/reposilite-frontend/src/store/placeholders.js
+++ b/reposilite-frontend/src/store/placeholders.js
@@ -23,6 +23,7 @@ export default function usePlaceholders() {
   const organizationWebsite = available ? '{{REPOSILITE.ORGANIZATION_WEBSITE}}' : location.protocol + '//' + location.host + basePath
   const organizationLogo = available ? '{{REPOSILITE.ORGANIZATION_LOGO}}' : 'https://avatars.githubusercontent.com/u/75123628?s=200&v=4'
   const privacyPolicy = available ? '{{REPOSILITE.PRIVACY_POLICY}}' : 'https://example.com/privacy'
+  const legalNotice = available ? '{{REPOSILITE.LEGAL_NOTICE}}' : 'https://example.com/legal'
   const icpLicense = available ? '{{REPOSILITE.ICP_LICENSE}}' : '国ICP备000000000号'
 
   const productionUrl =
@@ -42,6 +43,7 @@ export default function usePlaceholders() {
     organizationWebsite,
     organizationLogo,
     privacyPolicy,
+    legalNotice,
     icpLicense,
     productionUrl,
     baseUrl


### PR DESCRIPTION
This PR, similar to the privacy policy #2558, ads a configurable link to a legal notice page, which in some countries is required.