### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -73,6 +73,9 @@ jobs:
     name: "Docker"
     runs-on: ubuntu-latest
     needs: [ github ]
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/dzikoysk/reposilite/security/code-scanning/14](https://github.com/dzikoysk/reposilite/security/code-scanning/14)

Add an explicit `permissions` block to the `docker` job with least privileges required for its steps.

Best fix in this file:
- In `.github/workflows/publish-release.yml`, under `jobs.docker` (right after `runs-on` / `needs` is a good location), add:
  - `contents: read` (needed for checkout/read repository)
  - `packages: write` (needed to push to GHCR with `GITHUB_TOKEN`)

This keeps existing behavior intact while making token scope explicit and minimal.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
