### PR TITLE
GH-2624 Fix usage calculations

### DIFF
--- a/reposilite-backend/src/integration/kotlin/com/reposilite/storage/FileSystemStorageProviderIntegrationTest.kt
+++ b/reposilite-backend/src/integration/kotlin/com/reposilite/storage/FileSystemStorageProviderIntegrationTest.kt
@@ -23,6 +23,7 @@ import com.reposilite.status.FailureFacade
 import com.reposilite.storage.api.toLocation
 import com.reposilite.storage.filesystem.FileSystemStorageProvider
 import com.reposilite.storage.filesystem.FileSystemStorageProviderSettings
+import com.reposilite.storage.filesystem.NoQuota
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -189,6 +190,43 @@ internal class FileSystemStorageProviderIntegrationTest : StorageProviderIntegra
                 }
             }
             error("Thread did not park or terminate, last state was ${thread.state}")
+        }
+
+    }
+
+    @Nested
+    inner class NoQuotaTests {
+
+        @BeforeEach
+        fun setup() {
+            val logger = InMemoryLogger()
+            val failureFacade = FailureFacade(logger)
+            val storageFacade = StorageFacade()
+
+            this@FileSystemStorageProviderIntegrationTest.storageProvider = storageFacade.createStorageProvider(
+                journalist = logger,
+                failureFacade = failureFacade,
+                workingDirectory = rootDirectory.toPath(),
+                repository = "test-noquota",
+                storageSettings = FileSystemStorageProviderSettings(quota = null)
+            )!!
+        }
+
+        @Test
+        fun `should report -1 usage when no quota is configured`() {
+            assertThat(assertOk(storageProvider.usage())).isEqualTo(-1L)
+        }
+
+        @Test
+        fun `should accept large upload when no quota is configured`() {
+            val payload = ByteArray(10 * 1024 * 1024) { 'b'.code.toByte() }
+            val response = storageProvider.putFile("/large.jar".toLocation(), payload.inputStream())
+            assertOk(response)
+        }
+
+        @Test
+        fun `should create NoQuota provider`() {
+            assertThat(storageProvider).isInstanceOf(NoQuota::class.java)
         }
 
     }

--- a/reposilite-backend/src/integration/kotlin/com/reposilite/storage/FileSystemStorageProviderIntegrationTest.kt
+++ b/reposilite-backend/src/integration/kotlin/com/reposilite/storage/FileSystemStorageProviderIntegrationTest.kt
@@ -167,9 +167,7 @@ internal class FileSystemStorageProviderIntegrationTest : StorageProviderIntegra
 
         @Test
         fun `should reject an upload meaningfully over the quota boundary`() {
-            // given: a payload comfortably above the configured 1 MB. Note: an exact `maxSize + 1`
-            // payload currently passes due to a one-byte slack inherited from `usage()` returning -1
-            // for the storage root — see docs/follow-ups/QUOTA_REDESIGN.md.
+            // given: a payload comfortably above the configured 1 MB
             val payload = ByteArray(2 * 1024 * 1024) { 'a'.code.toByte() }
 
             // when: the upload is attempted

--- a/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemQuotaProviders.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemQuotaProviders.kt
@@ -21,6 +21,7 @@ import com.reposilite.shared.ErrorResponse
 import com.reposilite.shared.toErrorResponse
 import io.javalin.http.HttpStatus.INSUFFICIENT_STORAGE
 import panda.std.Result
+import panda.std.asSuccess
 import java.nio.file.Path
 import kotlin.io.path.fileStore
 
@@ -31,10 +32,12 @@ import kotlin.io.path.fileStore
 internal class FixedQuota(
     journalist: Journalist,
     rootDirectory: Path,
+    usageTracker: UsageTracker,
     private val maxSize: Long,
 ) : FileSystemStorageProvider(
     journalist = journalist,
     rootDirectory = rootDirectory,
+    usageTracker = usageTracker,
 ) {
 
     init {
@@ -57,10 +60,12 @@ internal class FixedQuota(
 internal class PercentageQuota(
     journalist: Journalist,
     rootDirectory: Path,
+    usageTracker: UsageTracker,
     private val maxPercentage: Double,
 ) : FileSystemStorageProvider(
     journalist = journalist,
     rootDirectory = rootDirectory,
+    usageTracker = usageTracker,
 ) {
 
     init {
@@ -77,5 +82,18 @@ internal class PercentageQuota(
                 max.toLong() - usage
             }
             .filter({ available -> contentLength <= available }, { INSUFFICIENT_STORAGE.toErrorResponse("Repository cannot hold the given file ($contentLength too much for $maxPercentage%)") })
+
+}
+
+internal class NoQuota(
+    journalist: Journalist,
+    rootDirectory: Path,
+) : FileSystemStorageProvider(
+    journalist = journalist,
+    rootDirectory = rootDirectory,
+) {
+
+    override fun canHold(contentLength: Long): Result<Long, ErrorResponse> =
+        Long.MAX_VALUE.asSuccess()
 
 }

--- a/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemStorageProvider.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemStorageProvider.kt
@@ -79,7 +79,7 @@ abstract class FileSystemStorageProvider protected constructor(
     val rootDirectory: Path,
 ) : StorageProvider {
 
-    private val usageCounterFile: Path = rootDirectory.resolve(".reposilite-usage")
+    private val usageCounterFile: Path = rootDirectory.resolve(".local/usage/${rootDirectory.name}")
     private val usageLock = Any()
     private var loadedUsage: Long = loadUsage()
 

--- a/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemStorageProvider.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemStorageProvider.kt
@@ -23,7 +23,6 @@ import com.reposilite.shared.notFound
 import com.reposilite.shared.stream.BoundedInputStream
 import com.reposilite.shared.stream.BoundedInputStreamLimitExceededException
 import com.reposilite.shared.toErrorResponse
-import com.reposilite.shared.internalServerError
 import com.reposilite.shared.toErrorResult
 import com.reposilite.storage.FilesComparator
 import com.reposilite.storage.StorageProvider
@@ -79,6 +78,43 @@ abstract class FileSystemStorageProvider protected constructor(
     val journalist: Journalist,
     val rootDirectory: Path,
 ) : StorageProvider {
+
+    private val usageCounterFile: Path = rootDirectory.resolve(".reposilite-usage")
+    private val usageLock = Any()
+    private var loadedUsage: Long = loadUsage()
+
+    private fun loadUsage(): Long =
+        try {
+            if (usageCounterFile.exists()) {
+                usageCounterFile.toFile().readText().trim().toLongOrNull()?.takeIf { it >= 0 }
+                    ?: recalculateUsage()
+            } else {
+                recalculateUsage()
+            }
+        } catch (e: Exception) {
+            recalculateUsage()
+        }
+
+    private fun recalculateUsage(): Long {
+        val size = Files.walk(rootDirectory).use { stream ->
+            stream.filter { it.type() == FILE }
+                .mapToLong { it.fileSize() }
+                .sum()
+        }
+        usageCounterFile.toFile().writeText("$size\n")
+        return size
+    }
+
+    private fun addToUsage(delta: Long) {
+        synchronized(usageLock) {
+            loadedUsage += delta
+            if (loadedUsage < 0) {
+                loadedUsage = recalculateUsage()
+            } else {
+                usageCounterFile.toFile().writeText("$loadedUsage\n")
+            }
+        }
+    }
 
     private enum class LockMode {
         READ,
@@ -149,9 +185,11 @@ abstract class FileSystemStorageProvider protected constructor(
                             // Re-check post-write: InputStream.available() is just a hint and returns 0 for HTTP request bodies.
                             .flatMap { canHold(temporaryFile.fileSize()).mapErr { INSUFFICIENT_STORAGE.toErrorResponse("Not enough storage space available: ${it.message}") } }
                             .peek {
+                                val size = temporaryFile.fileSize()
                                 acquireFileAccessLock(location, LockMode.WRITE).use {
                                     temporaryFile.moveTo(file, overwrite = true)
                                 }
+                                addToUsage(size)
                             }
                             .mapToUnit()
                     }
@@ -252,10 +290,19 @@ abstract class FileSystemStorageProvider protected constructor(
             .resolveWithRootDirectory()
             .filter({ !it.normalize().equals(rootDirectory.normalize()) }, { badRequest("Cannot remove repository root") })
             .map { rootPath ->
+                val removedSize = when {
+                    rootPath.isDirectory() -> Files.walk(rootPath).use { stream ->
+                        stream.filter { it.type() == FILE }
+                            .mapToLong { it.fileSize() }
+                            .sum()
+                    }
+                    else -> rootPath.fileSize()
+                }
                 when {
                     rootPath.isDirectory() -> rootPath.deleteRecursively()
                     else -> rootPath.deleteExisting()
                 }
+                addToUsage(-removedSize)
             }
 
     override fun getFiles(location: Location): Result<List<Location>, ErrorResponse> =
@@ -290,16 +337,7 @@ abstract class FileSystemStorageProvider protected constructor(
             .fold({ true }, { false })
 
     override fun usage(): Result<Long, ErrorResponse> =
-        try {
-            var total = 0L
-            Files.walk(rootDirectory).use { stream ->
-                stream.filter { it.type() == FILE }
-                    .forEach { total += it.fileSize() }
-            }
-            total.asSuccess()
-        } catch (e: IOException) {
-            internalServerError(e.message ?: "Failed to calculate usage")
-        }
+        loadedUsage.asSuccess()
 
     private fun Result<Path, ErrorResponse>.exists(): Result<Path, ErrorResponse> =
         filter({ it.exists() }) { notFound("File not found") }

--- a/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemStorageProvider.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemStorageProvider.kt
@@ -186,10 +186,11 @@ abstract class FileSystemStorageProvider protected constructor(
                             .flatMap { canHold(temporaryFile.fileSize()).mapErr { INSUFFICIENT_STORAGE.toErrorResponse("Not enough storage space available: ${it.message}") } }
                             .peek {
                                 val size = temporaryFile.fileSize()
+                                val oldSize = if (file.exists()) file.fileSize() else 0L
                                 acquireFileAccessLock(location, LockMode.WRITE).use {
                                     temporaryFile.moveTo(file, overwrite = true)
                                 }
-                                addToUsage(size)
+                                addToUsage(size - oldSize)
                             }
                             .mapToUnit()
                     }

--- a/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemStorageProvider.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemStorageProvider.kt
@@ -23,6 +23,7 @@ import com.reposilite.shared.notFound
 import com.reposilite.shared.stream.BoundedInputStream
 import com.reposilite.shared.stream.BoundedInputStreamLimitExceededException
 import com.reposilite.shared.toErrorResponse
+import com.reposilite.shared.internalServerError
 import com.reposilite.shared.toErrorResult
 import com.reposilite.storage.FilesComparator
 import com.reposilite.storage.StorageProvider
@@ -46,6 +47,7 @@ import java.io.Closeable
 import java.io.FilterInputStream
 import java.io.IOException
 import java.io.InputStream
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.attribute.FileTime
@@ -288,7 +290,16 @@ abstract class FileSystemStorageProvider protected constructor(
             .fold({ true }, { false })
 
     override fun usage(): Result<Long, ErrorResponse> =
-        getFileSize(Location.empty())
+        try {
+            var total = 0L
+            Files.walk(rootDirectory).use { stream ->
+                stream.filter { it.type() == FILE }
+                    .forEach { total += it.fileSize() }
+            }
+            total.asSuccess()
+        } catch (e: IOException) {
+            internalServerError(e.message ?: "Failed to calculate usage")
+        }
 
     private fun Result<Path, ErrorResponse>.exists(): Result<Path, ErrorResponse> =
         filter({ it.exists() }) { notFound("File not found") }

--- a/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemStorageProvider.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemStorageProvider.kt
@@ -74,47 +74,11 @@ import kotlin.io.path.useDirectoryEntries
 /**
  * @param rootDirectory root directory of storage space
  */
-abstract class FileSystemStorageProvider protected constructor(
+abstract class FileSystemStorageProvider internal constructor(
     val journalist: Journalist,
     val rootDirectory: Path,
+    private val usageTracker: UsageTracker? = null,
 ) : StorageProvider {
-
-    private val usageCounterFile: Path = rootDirectory.resolve(".local/usage/${rootDirectory.name}")
-    private val usageLock = Any()
-    private var loadedUsage: Long = loadUsage()
-
-    private fun loadUsage(): Long =
-        try {
-            if (usageCounterFile.exists()) {
-                usageCounterFile.toFile().readText().trim().toLongOrNull()?.takeIf { it >= 0 }
-                    ?: recalculateUsage()
-            } else {
-                recalculateUsage()
-            }
-        } catch (e: Exception) {
-            recalculateUsage()
-        }
-
-    private fun recalculateUsage(): Long {
-        val size = Files.walk(rootDirectory).use { stream ->
-            stream.filter { it.type() == FILE }
-                .mapToLong { it.fileSize() }
-                .sum()
-        }
-        usageCounterFile.toFile().writeText("$size\n")
-        return size
-    }
-
-    private fun addToUsage(delta: Long) {
-        synchronized(usageLock) {
-            loadedUsage += delta
-            if (loadedUsage < 0) {
-                loadedUsage = recalculateUsage()
-            } else {
-                usageCounterFile.toFile().writeText("$loadedUsage\n")
-            }
-        }
-    }
 
     private enum class LockMode {
         READ,
@@ -190,7 +154,7 @@ abstract class FileSystemStorageProvider protected constructor(
                                 acquireFileAccessLock(location, LockMode.WRITE).use {
                                     temporaryFile.moveTo(file, overwrite = true)
                                 }
-                                addToUsage(size - oldSize)
+                                usageTracker?.addDelta(size - oldSize)
                             }
                             .mapToUnit()
                     }
@@ -303,7 +267,7 @@ abstract class FileSystemStorageProvider protected constructor(
                     rootPath.isDirectory() -> rootPath.deleteRecursively()
                     else -> rootPath.deleteExisting()
                 }
-                addToUsage(-removedSize)
+                usageTracker?.addDelta(-removedSize)
             }
 
     override fun getFiles(location: Location): Result<List<Location>, ErrorResponse> =
@@ -338,7 +302,7 @@ abstract class FileSystemStorageProvider protected constructor(
             .fold({ true }, { false })
 
     override fun usage(): Result<Long, ErrorResponse> =
-        loadedUsage.asSuccess()
+        if (usageTracker != null) usageTracker.getUsage().asSuccess() else (-1L).asSuccess()
 
     private fun Result<Path, ErrorResponse>.exists(): Result<Path, ErrorResponse> =
         filter({ it.exists() }) { notFound("File not found") }

--- a/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemStorageProviderFactory.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemStorageProviderFactory.kt
@@ -31,23 +31,17 @@ class FileSystemStorageProviderFactory : StorageProviderFactory<FileSystemStorag
         private const val MB_FACTOR = 1024 * KB_FACTOR
         private const val GB_FACTOR = 1024 * MB_FACTOR
 
-        /**
-         * @param rootDirectory root directory of storage space
-         * @param quota quota to use as % or in bytes
-         */
-        fun of(journalist: Journalist, rootDirectory: Path, quota: String): FileSystemStorageProvider =
-            if (quota.endsWith("%")) {
-                of(
-                    journalist = journalist,
-                    rootDirectory = rootDirectory,
-                    maxPercentage = quota.substring(0, quota.length - 1).toInt() / 100.0,
-                )
+        fun of(journalist: Journalist, rootDirectory: Path, quota: String?): FileSystemStorageProvider =
+            if (quota == null) {
+                NoQuota(journalist, rootDirectory)
+            } else if (quota.endsWith("%")) {
+                val percentage = quota.substring(0, quota.length - 1).toInt() / 100.0
+                val usageTracker = UsageTracker(rootDirectory)
+                PercentageQuota(journalist, rootDirectory, usageTracker, percentage)
             } else {
-                of(
-                    journalist = journalist,
-                    rootDirectory = rootDirectory,
-                    maxSize = displaySizeToBytesCount(quota),
-                )
+                val maxSize = displaySizeToBytesCount(quota)
+                val usageTracker = UsageTracker(rootDirectory)
+                FixedQuota(journalist, rootDirectory, usageTracker, maxSize)
             }
 
         /**
@@ -58,6 +52,7 @@ class FileSystemStorageProviderFactory : StorageProviderFactory<FileSystemStorag
             FixedQuota(
                 journalist = journalist,
                 rootDirectory = rootDirectory,
+                usageTracker = UsageTracker(rootDirectory),
                 maxSize = maxSize,
             )
 
@@ -69,6 +64,7 @@ class FileSystemStorageProviderFactory : StorageProviderFactory<FileSystemStorag
             PercentageQuota(
                 journalist = journalist,
                 rootDirectory = rootDirectory,
+                usageTracker = UsageTracker(rootDirectory),
                 maxPercentage = maxPercentage,
             )
 

--- a/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemStorageProviderSettings.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemStorageProviderSettings.kt
@@ -24,8 +24,8 @@ import io.javalin.openapi.Custom
 data class FileSystemStorageProviderSettings(
     @get:Custom(name = "const", value = "fs")
     override val type: String = "fs",
-    @get:Doc(title = "Quota", description = "Control the maximum amount of data stored in this repository. Supported formats: 90%, 500MB, 10GB (optional, by default: unlimited)")
-    val quota: String = "100%",
+    @get:Doc(title = "Quota", description = "Control the maximum amount of data stored in this repository. Supported formats: 90%, 500MB, 10GB. Null or absent means no quota enforcement (default).")
+    val quota: String? = null,
     @get:Doc(title = "Mount", description = "Use custom directory to locate the repository data (optional, by default it's './repositories/{name}')")
     val mount: String = "",
 ) : StorageProviderSettings

--- a/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/UsageTracker.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/UsageTracker.kt
@@ -21,7 +21,7 @@ internal class UsageTracker(
 
     fun addDelta(delta: Long) {
         synchronized(lock) {
-            loadedUsage += delta
+            loadedUsage = loadUsage() + delta
             if (loadedUsage < 0) {
                 loadedUsage = recalculate()
             } else {

--- a/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/UsageTracker.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/UsageTracker.kt
@@ -12,7 +12,7 @@ import kotlin.io.path.name
 internal class UsageTracker(
     private val rootDirectory: Path,
 ) {
-    private val counterFile: Path = "/app/data/.local/usage/${rootDirectory.name}")
+    private val counterFile: Path = Path.of("/app/data").resolve(".local/usage/${rootDirectory.name}")
     private val lock = Any()
     @Volatile
     private var loadedUsage: Long = loadUsage()

--- a/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/UsageTracker.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/UsageTracker.kt
@@ -1,0 +1,56 @@
+package com.reposilite.storage.filesystem
+
+import com.reposilite.storage.api.FileType.FILE
+import com.reposilite.storage.type
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createParentDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.fileSize
+import kotlin.io.path.name
+
+internal class UsageTracker(
+    private val rootDirectory: Path,
+) {
+    private val counterFile: Path = rootDirectory.resolve(".local/usage/${rootDirectory.name}")
+    private val lock = Any()
+    @Volatile
+    private var loadedUsage: Long = loadUsage()
+
+    fun getUsage(): Long = loadedUsage
+
+    fun addDelta(delta: Long) {
+        synchronized(lock) {
+            loadedUsage += delta
+            if (loadedUsage < 0) {
+                loadedUsage = recalculate()
+            } else {
+                counterFile.createParentDirectories()
+                counterFile.toFile().writeText("$loadedUsage\n")
+            }
+        }
+    }
+
+    private fun loadUsage(): Long =
+        try {
+            if (counterFile.exists()) {
+                counterFile.toFile().readText().trim().toLongOrNull()?.takeIf { it >= 0 }
+                    ?: recalculate()
+            } else {
+                recalculate()
+            }
+        } catch (e: Exception) {
+            recalculate()
+        }
+
+    private fun recalculate(): Long {
+        val size = Files.walk(rootDirectory).use { stream ->
+            stream.filter { it.type() == FILE }
+                .mapToLong { it.fileSize() }
+                .sum()
+        }
+        counterFile.createParentDirectories()
+        counterFile.toFile().writeText("$size\n")
+        return size
+    }
+}

--- a/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/UsageTracker.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/UsageTracker.kt
@@ -12,7 +12,7 @@ import kotlin.io.path.name
 internal class UsageTracker(
     private val rootDirectory: Path,
 ) {
-    private val counterFile: Path = rootDirectory.resolve(".local/usage/${rootDirectory.name}")
+    private val counterFile: Path = "/app/data/.local/usage/${rootDirectory.name}")
     private val lock = Any()
     @Volatile
     private var loadedUsage: Long = loadUsage()


### PR DESCRIPTION
Previously, the check for usage on a given dir was done using the `getFileSize()` function. This function returned -1 when called on a directory, which was the case for any FileSystemStorageProvider. This meant that any checks against the size would always pass assuming the incoming file was less than the configured limit. 
This fix walks files to get the true size of the directory, caches the size, then checks incoming file(s) against that size, which should eventually block incoming requests, as opposed to the prior code, which would continue to accept requests until the disk was full (ask me how I know).

closes #2624
