### PR TITLE
Fix broken image paths in documentation guides

### DIFF
--- a/reposilite-site/data/guides/authentication/tokens.md
+++ b/reposilite-site/data/guides/authentication/tokens.md
@@ -65,7 +65,7 @@ If you're confused about your first auth configuration, you may find this video 
 
   <Spoiler title="Open visualization">
     <video controls>
-      <source src="/images/guides/token-generate.webm" type="video/webm" />
+      <source src="../../../public/images/guides/token-generate.webm" type="video/webm" />
       Your browser does not support the video tag.
     </video>
   </Spoiler>

--- a/reposilite-site/data/guides/deployment/github.md
+++ b/reposilite-site/data/guides/deployment/github.md
@@ -9,7 +9,7 @@ Before you can start working with [GitHub Actions](https://github.com/features/a
 you have to add access token to your environment.
 You can do this in `Your repository -> Settings -> Security -> Secrets and variables -> Actions`:
 
-![GitHub Actions :: Secret](/images/guides/github-actions-secrets.png)
+![GitHub Actions :: Secret](../../../public/images/guides/github-actions-secrets.png)
 
 Defined variables can be used in workflow files using the given syntax: `${{ secrets.VARIABLE }}`.
 

--- a/reposilite-site/data/guides/features/dashboard.md
+++ b/reposilite-site/data/guides/features/dashboard.md
@@ -8,17 +8,17 @@ Reposilite exposes a frontend that is mounted to `/#/` as [SPA _(single-page app
 #### Browser
 Browser displays the content of the currently selected directory in respect to the provided authentication credentials. For users not logged in it lists only public files, for authenticated users it also displays files that the user has access to.
 
-![Dashboard Browser Preview](/images/guides/dashboard-browser-preview.png)
+![Dashboard Browser Preview](../../../public/images/guides/dashboard-browser-preview.png)
 
 You can control how Reposilite displays directory content by opening the adjustments view via the icon in the top-right corner:
 
-![Browser Adjustments](/images/guides/dashboard-browser-adjustments.png)
+![Browser Adjustments](../../../public/images/guides/dashboard-browser-adjustments.png)
 
 #### Console
 
 CLI _(command-line interface)_ displays the current Reposilite output and allows to perform available [commands](/guide/standalone#interactive-cli). Only access tokens with management permission can access this view.
 
-![CLI Preview](/images/guides/dashboard-console.png)
+![CLI Preview](../../../public/images/guides/dashboard-console.png)
 
 You can also filter those messages using filters, but keep in mind that it searches only through the currently cached log entries, not the whole history.
 
@@ -29,7 +29,7 @@ Shared configuration has been already mentioned in:
 
 Currently, configuration is provided in [CDN _(Configuration Data Notation)_](https://github.com/dzikoysk/cdn) format:
 
-![Dashboard / Configuration](/images/guides/web-interface-configuration.png)
+![Dashboard / Configuration](../../../public/images/guides/web-interface-configuration.png)
 
 You can modify it and reload changes. Most of the properties support hot-reloading,
 so you should see changes immediately _(visual updates after reloading the page)_.

--- a/reposilite-site/data/guides/features/mirrors.md
+++ b/reposilite-site/data/guides/features/mirrors.md
@@ -8,14 +8,14 @@ To simplify & speed up your build process,
 you can list all of these repositories in `Mirrored repositories` section 
 and Reposilite will also search for requested artifacts among them:
 
-![Mirrored Repositories](/images/guides/mirrored-repositories.png)
+![Mirrored Repositories](../../../public/images/guides/mirrored-repositories.png)
 
 **Note**: Remember about increasing disk quota! 
 Caching may allocate thousands of artifacts, especially at the beginning - for the first few builds. 
 
 <Spoiler title="Disk quota configuration">
 
-![Disk Quota](/images/guides/disk-quota.png)
+![Disk Quota](../../../public/images/guides/disk-quota.png)
 
 Stable Reposilite instance should guarantee much better availability than any other public repository - even Maven Central repository.
 

--- a/reposilite-site/data/guides/features/repositories.md
+++ b/reposilite-site/data/guides/features/repositories.md
@@ -41,4 +41,4 @@ Reposilite can mirror (proxy) other repositories:
 ### Custom repository
 You can also define a new one by just adding it in the configuration:
 
-![Configuration](/images/guides/settings-repositories.png)
+![Configuration](../../../public/images/guides/settings-repositories.png)

--- a/reposilite-site/data/guides/features/s3.md
+++ b/reposilite-site/data/guides/features/s3.md
@@ -26,7 +26,7 @@ You can also share a single bucket across multiple repositories (or with other s
 
 S3 configuration can be defined in the `Dashboard -> Settings -> Maven -> <Repository>` section:
 
-![S3 Configuration](/images/guides/s3-config.png)
+![S3 Configuration](../../../public/images/guides/s3-config.png)
 
 These values depend on your S3 provider & its configuration, 
 so you have to check their documentation to find out how to configure them.

--- a/reposilite-site/data/guides/infrastructure/cloudflare.md
+++ b/reposilite-site/data/guides/infrastructure/cloudflare.md
@@ -10,10 +10,10 @@ To avoid these problems, you have to exclude Reposilite from cached resources.
 
 If you use Cloudflare - you can set `Cache Level` property to `Bypass` through the custom page rules (`Rules` -> `Page Rules`):
 
-![Rules](/images/guides/cloudflare-cache-bypass-rules.png)
+![Rules](../../../public/images/guides/cloudflare-cache-bypass-rules.png)
 
-![Rules Settings](/images/guides/cloudflare-cache-bypass-rules-settings.png)
+![Rules Settings](../../../public/images/guides/cloudflare-cache-bypass-rules-settings.png)
 
-![Cache Bypass](/images/guides/cloudflare-cache-bypass.png)
+![Cache Bypass](../../../public/images/guides/cloudflare-cache-bypass.png)
 
 Associated issue on GitHub: [GH-156 Wrong artifact is being downloaded](https://github.com/dzikoysk/reposilite/issues/156)

--- a/reposilite-site/data/guides/installation/general.md
+++ b/reposilite-site/data/guides/installation/general.md
@@ -167,7 +167,7 @@ due to the lack of 3rd party service that could broadcast data between instances
 
 Shared configuration can be modified by access token with management permission through web interface in _Settings_ tab:
 
-![Dashboard / Configuration](/images/guides/web-interface-configuration.png)
+![Dashboard / Configuration](../../../public/images/guides/web-interface-configuration.png)
 
 #### Shared configuration as file
 

--- a/reposilite-site/data/guides/installation/jar.md
+++ b/reposilite-site/data/guides/installation/jar.md
@@ -37,7 +37,7 @@ $ java -Xmx32M -jar reposilite.jar
 Reposilite exposes interactive console directly in a terminal and it awaits for an input.
 Type `help` and learn more about available commands.
 
-![Interactive CLI](/images/guides/interactive-cli.gif)
+![Interactive CLI](../../../public/images/guides/interactive-cli.gif)
 
 `Note` Your first access token has to be generated through the terminal or provided as a command line argument.  
 Read more about tokens and token management commands in [Guide / Tokens](/guide/tokens).
@@ -47,7 +47,7 @@ Read more about tokens and token management commands in [Guide / Tokens](/guide/
 If Reposilite has been launched properly,
 you should be able to see its frontend located under the default http://localhost:8080/#/ address.
 
-![Web Interface Preview](/images/guides/web-interface-preview.png)
+![Web Interface Preview](../../../public/images/guides/web-interface-preview.png)
 
 ### Data structure
 


### PR DESCRIPTION
## Problem

Images in several guide pages were broken because the paths referenced
`/images/guides/` but the assets live under `public/images/guides/`.

<img width="1726" height="959" alt="image" src="https://github.com/user-attachments/assets/316e67d0-2ece-477f-866d-0b107da82361" />

## Changes

Updated image references in files:

- reposilite-site/data/guides/features/mirrors.md
- reposilite-site/data/guides/authentication/tokens.md
- reposilite-site/data/guides/deployment/github.md
- reposilite-site/data/guides/features/dashboard.md
- reposilite-site/data/guides/features/repositories.md
- reposilite-site/data/guides/features/s3.md
- reposilite-site/data/guides/infrastructure/cloudflare.md
- reposilite-site/data/guides/installation/general.md
- reposilite-site/data/guides/installation/jar.md

All image references updated from `/images/guides/<file>` →
`/public/images/guides/<file>`.

## Testing

<img width="1600" height="1595" alt="image" src="https://github.com/user-attachments/assets/d38010b5-bb0e-46ce-8cb2-23c98ae9e3ec" />