### PR TITLE
GH-2680 Fix link for installation not going to the propper place

### DIFF
--- a/reposilite-site/components/layout/Footer.js
+++ b/reposilite-site/components/layout/Footer.js
@@ -8,7 +8,7 @@ const link = (title, url) =>
 
 const guideLinks = [
   link('Getting Started', '/guide/about'),
-  link('Installation', 'guide/general'),
+  link('Installation', '/guide/general'),
   link('Plugins', '/plugin'),
   link('Developer API', '/guide/sources'),
 ]


### PR DESCRIPTION
If you are already in /guide it will go to /guide/guide/general for example. This behaviour was caused by the link being guide/general not /guide/general which means that it would link to the incorrect place