### PR TITLE
GH-2056 Add blockedGroups to mirrored repository settings

### DIFF
--- a/reposilite-backend/src/main/kotlin/com/reposilite/maven/MirrorService.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/maven/MirrorService.kt
@@ -204,7 +204,8 @@ internal class MirrorService(
 
     private enum class DisallowedReason {
         EXTENSION,
-        GROUP
+        GROUP,
+        BLOCKED_GROUP
     }
 
     private fun isAllowed(config: MirroredRepositorySettings, gav: Location): Result<Blank, DisallowedReason> =
@@ -225,10 +226,17 @@ internal class MirrorService(
 
     private fun isAllowedGroup(config: MirroredRepositorySettings, gav: Location): Result<Blank, DisallowedReason> =
         when {
+            isBlockedGroup(config, gav) -> error(DisallowedReason.BLOCKED_GROUP)
             config.allowedGroups.none { it.isNotBlank() } -> ok()
-            config.allowedGroups.any { gav.toString().startsWith(it.replace('.', '/')) } -> ok()
+            config.allowedGroups.any { matchesGroup(it, gav) } -> ok()
             else -> error(DisallowedReason.GROUP)
         }
+
+    private fun isBlockedGroup(config: MirroredRepositorySettings, gav: Location): Boolean =
+        config.blockedGroups.any { it.isNotBlank() && matchesGroup(it.trim(), gav) }
+
+    private fun matchesGroup(entry: String, gav: Location): Boolean =
+        gav.toString().startsWith(entry.replace('.', '/'))
 
     override fun getLogger(): Logger =
         journalist.logger

--- a/reposilite-backend/src/main/kotlin/com/reposilite/maven/application/MavenSettings.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/maven/application/MavenSettings.kt
@@ -92,6 +92,8 @@ data class MirroredRepositorySettings(
     val store: Boolean = false,
     @get:Doc(title = "Allowed Groups", description = "Allowed artifact groups. If none are given, all artifacts can be obtained from this mirror.")
     val allowedGroups: List<String> = listOf(),
+    @get:Doc(title = "Blocked Groups", description = "Artifact groups that are never requested from this mirror. Takes precedence over Allowed Groups. Matched as a path prefix, so 'com.acme' also blocks 'com.acmecorp' - prefer the most specific group you can.")
+    val blockedGroups: List<String> = listOf(),
     @get:Doc(title = "Allowed Extensions", description = "List of accepted file extensions. If none are given, all files can be obtained from this mirror. Use the special value '&lt;none&gt;' to permit files without an extension (e.g. native binaries).")
     val allowedExtensions: List<String> = listOf(".jar", ".war", ".aar", ".pom", ".xml", ".module", ".md5", ".sha1", ".sha256", ".sha512", ".asc"),
     @Min(0)

--- a/reposilite-backend/src/test/kotlin/com/reposilite/maven/MavenFacadeTest.kt
+++ b/reposilite-backend/src/test/kotlin/com/reposilite/maven/MavenFacadeTest.kt
@@ -72,6 +72,18 @@ internal class MavenFacadeTest : MavenSpecification() {
         )),
         RepositorySettings("PROXIED-BLANK-EXTENSIONS", visibility = HIDDEN, proxied = mutableListOf(
             MirroredRepositorySettings(reference = REMOTE_REPOSITORY, store = true, authorization = REMOTE_AUTH, allowedExtensions = listOf(""))
+        )),
+        RepositorySettings("PROXIED-BLOCKED-GROUPS", visibility = HIDDEN, proxied = mutableListOf(
+            MirroredRepositorySettings(reference = REMOTE_REPOSITORY, store = true, authorization = REMOTE_AUTH, blockedGroups = listOf("com.blocked"))
+        )),
+        RepositorySettings("PROXIED-ALLOW-AND-BLOCK", visibility = HIDDEN, proxied = mutableListOf(
+            MirroredRepositorySettings(reference = REMOTE_REPOSITORY, store = true, authorization = REMOTE_AUTH, allowedGroups = listOf("com.both"), blockedGroups = listOf("com.both"))
+        )),
+        RepositorySettings("PROXIED-BLANK-BLOCKED-GROUPS", visibility = HIDDEN, proxied = mutableListOf(
+            MirroredRepositorySettings(reference = REMOTE_REPOSITORY, store = true, authorization = REMOTE_AUTH, blockedGroups = listOf("", "com.blocked"))
+        )),
+        RepositorySettings("PROXIED-PADDED-BLOCKED-GROUPS", visibility = HIDDEN, proxied = mutableListOf(
+            MirroredRepositorySettings(reference = REMOTE_REPOSITORY, store = true, authorization = REMOTE_AUTH, blockedGroups = listOf(" com.blocked "))
         ))
     )
 
@@ -307,6 +319,98 @@ internal class MavenFacadeTest : MavenSpecification() {
 
             // then: it is rejected by the extension filter
             assertError(response)
+        }
+
+        @Test
+        fun `should not request a blocked group from the mirror`() {
+            // given: an artifact the upstream would happily serve, in a blocked group
+            val file = FileSpec("PROXIED-BLOCKED-GROUPS", "/com/blocked/artifact.jar", REMOTE_CONTENT)
+
+            // when: the file is requested
+            val response = mavenFacade.findFile(file.toLookupRequest(UNAUTHORIZED))
+
+            // then: it is not found and no upstream request is issued
+            assertError(response)
+            assertThat(remoteRequestsByUri["$REMOTE_REPOSITORY/com/blocked/artifact.jar"]).isNull()
+        }
+
+        @Test
+        fun `should serve a locally stored artifact from a blocked group`() {
+            // given: an artifact in a blocked group already present in local storage
+            val file = addFileToRepository(FileSpec("PROXIED-BLOCKED-GROUPS", "/com/blocked/local.jar", "local-content"))
+
+            // when: the file is requested
+            val response = mavenFacade.findFile(file.toLookupRequest(UNAUTHORIZED))
+
+            // then: it resolves from local storage without contacting the mirror
+            val (_, data) = assertOk(response)
+            assertThat(data.readBytes().decodeToString()).isEqualTo("local-content")
+            assertThat(remoteRequestsByUri["$REMOTE_REPOSITORY/com/blocked/local.jar"]).isNull()
+        }
+
+        @Test
+        fun `should block a group present in both allowed and blocked lists`() {
+            // given: a group named in allowedGroups and blockedGroups alike
+            val file = FileSpec("PROXIED-ALLOW-AND-BLOCK", "/com/both/artifact.jar", REMOTE_CONTENT)
+
+            // when: the file is requested
+            val response = mavenFacade.findFile(file.toLookupRequest(UNAUTHORIZED))
+
+            // then: block wins
+            assertError(response)
+            assertThat(remoteRequestsByUri["$REMOTE_REPOSITORY/com/both/artifact.jar"]).isNull()
+        }
+
+        @Test
+        fun `should ignore blank entries in blocked groups`() {
+            // given: a blockedGroups list containing a blank alongside a real entry
+            val file = FileSpec("PROXIED-BLANK-BLOCKED-GROUPS", "/com/unrelated/artifact.jar", REMOTE_CONTENT)
+
+            // when: an unrelated group is requested
+            val response = mavenFacade.findFile(file.toLookupRequest(UNAUTHORIZED))
+
+            // then: the blank entry does not block it
+            val (_, data) = assertOk(response)
+            assertThat(data.readBytes().decodeToString()).isEqualTo(REMOTE_CONTENT)
+        }
+
+        @Test
+        fun `should still block real entries alongside a blank entry`() {
+            // given: the same list, now requesting the genuinely blocked group
+            val file = FileSpec("PROXIED-BLANK-BLOCKED-GROUPS", "/com/blocked/artifact.jar", REMOTE_CONTENT)
+
+            // when: the file is requested
+            val response = mavenFacade.findFile(file.toLookupRequest(UNAUTHORIZED))
+
+            // then: it is blocked and no request is issued
+            assertError(response)
+            assertThat(remoteRequestsByUri["$REMOTE_REPOSITORY/com/blocked/artifact.jar"]).isNull()
+        }
+
+        @Test
+        fun `should block a group sharing a raw prefix with a blocked group`() {
+            // given: blockedGroups contains 'com.blocked' and the request is for 'com.blockedcorp'
+            val file = FileSpec("PROXIED-BLOCKED-GROUPS", "/com/blockedcorp/artifact.jar", REMOTE_CONTENT)
+
+            // when: the file is requested
+            val response = mavenFacade.findFile(file.toLookupRequest(UNAUTHORIZED))
+
+            // then: it is blocked too
+            assertError(response)
+            assertThat(remoteRequestsByUri["$REMOTE_REPOSITORY/com/blockedcorp/artifact.jar"]).isNull()
+        }
+
+        @Test
+        fun `should block a whitespace padded group entry`() {
+            // given: a blockedGroups entry padded with whitespace, as the settings UI easily produces
+            val file = FileSpec("PROXIED-PADDED-BLOCKED-GROUPS", "/com/blocked/artifact.jar", REMOTE_CONTENT)
+
+            // when: the file is requested
+            val response = mavenFacade.findFile(file.toLookupRequest(UNAUTHORIZED))
+
+            // then: the padding is ignored and the group is still blocked
+            assertError(response)
+            assertThat(remoteRequestsByUri["$REMOTE_REPOSITORY/com/blocked/artifact.jar"]).isNull()
         }
 
         @Test

--- a/reposilite-site/data/guides/features/mirrors.md
+++ b/reposilite-site/data/guides/features/mirrors.md
@@ -53,6 +53,38 @@ org.reposilite
 
 If the list is empty, all groups are allowed.
 
+#### Blocked groups
+You can also block specific groups from being proxied through this mirror, e.g.:
+
+```bash
+com.internal
+```
+
+Groups listed here are never requested from this mirror.
+Blocked groups take precedence over allowed groups, so a group that appears in both lists is blocked.
+
+Mirrors are consulted in the order they are configured, and the first one to answer wins.
+Two situations follow from that:
+
+- Steering resolution. When two mirrors carry the same group at different versions,
+  block the group on the mirror that should not answer for it,
+  and resolution falls through to the mirror that should.
+- Dependency confusion. If someone publishes an artifact under one of your internal groups
+  to a public repository you proxy, that mirror may answer ahead of the mirror
+  that should serve the group. Blocking your internal groups on every public mirror
+  removes that possibility.
+
+Matching is a path prefix, so `com.acme` also blocks `com.acmecorp` - prefer the most specific group you can.
+
+Blocking a group only suppresses the upstream fetch.
+Artifacts already stored locally under a blocked group still resolve normally from local storage,
+so blocking prevents future fetches rather than retracting past ones -
+delete the cached artifact as well if you need it gone.
+
+When a mirror's Link references another local repository by ID rather than a URL,
+blocking a group on that entry also suppresses reads of the referenced repository's cached artifacts.
+For that reason, `blockedGroups` belongs on mirror entries whose Link is a URL.
+
 #### Allowed extensions
 You can limit the scope of proxied artifacts by specifying list of allowed extensions.
 By default, Reposilite allows these extensions:


### PR DESCRIPTION
…2056)

Mirror resolution returns the first host that answers, in configured order, so a group carried by several mirrors is served by whichever comes first - returning a stale version, or letting a public mirror answer for an internal group ahead of the mirror that should serve it.

allowedGroups cannot correct this: confining a mirror to the groups it should answer for means enumerating every other group it must still serve. blockedGroups inverts that, and is checked first so it takes precedence.

Matching reuses the existing raw path-prefix test. Blank entries are ignored. Only the mirror leg is suppressed - artifacts in local storage still resolve.