### PR TITLE
Added a file permission option for each Maven repository.

### DIFF
--- a/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemQuotaProviders.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemQuotaProviders.kt
@@ -22,6 +22,7 @@ import com.reposilite.shared.toErrorResponse
 import io.javalin.http.HttpStatus.INSUFFICIENT_STORAGE
 import panda.std.Result
 import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
 import kotlin.io.path.fileStore
 
 /**
@@ -32,9 +33,11 @@ internal class FixedQuota(
     journalist: Journalist,
     rootDirectory: Path,
     private val maxSize: Long,
+    filePermissions: Set<PosixFilePermission>,
 ) : FileSystemStorageProvider(
     journalist = journalist,
     rootDirectory = rootDirectory,
+    filePermissions = filePermissions,
 ) {
 
     init {
@@ -58,9 +61,11 @@ internal class PercentageQuota(
     journalist: Journalist,
     rootDirectory: Path,
     private val maxPercentage: Double,
+    filePermissions: Set<PosixFilePermission>,
 ) : FileSystemStorageProvider(
     journalist = journalist,
     rootDirectory = rootDirectory,
+    filePermissions = filePermissions,
 ) {
 
     init {

--- a/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemStorageProvider.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemStorageProvider.kt
@@ -46,9 +46,11 @@ import java.io.Closeable
 import java.io.FilterInputStream
 import java.io.IOException
 import java.io.InputStream
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.attribute.FileTime
+import java.nio.file.attribute.PosixFilePermission
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -76,6 +78,7 @@ import kotlin.io.path.useDirectoryEntries
 abstract class FileSystemStorageProvider protected constructor(
     val journalist: Journalist,
     val rootDirectory: Path,
+    private val filePermissions: Set<PosixFilePermission>,
 ) : StorageProvider {
 
     private enum class LockMode {
@@ -149,12 +152,21 @@ abstract class FileSystemStorageProvider protected constructor(
                             .peek {
                                 acquireFileAccessLock(location, LockMode.WRITE).use {
                                     temporaryFile.moveTo(file, overwrite = true)
+                                    setFilePermissions(file)
                                 }
                             }
                             .mapToUnit()
                     }
                 }
         }
+
+    private fun setFilePermissions(file: Path) {
+        try {
+            Files.setPosixFilePermissions(file, filePermissions)
+        } catch (_: UnsupportedOperationException) {
+            // POSIX permissions are not available on all file systems (for example, Windows).
+        }
+    }
 
     private inline fun <T> useTempFile(block: (Path) -> T): T {
         val temporaryFile = createTempFile("reposilite-", "-fs-put")

--- a/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemStorageProviderFactory.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemStorageProviderFactory.kt
@@ -20,6 +20,8 @@ import com.reposilite.journalist.Journalist
 import com.reposilite.status.FailureFacade
 import com.reposilite.storage.StorageProviderFactory
 import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.attribute.PosixFilePermissions
 import java.util.regex.Pattern
 import kotlin.io.path.createDirectories
 
@@ -30,23 +32,31 @@ class FileSystemStorageProviderFactory : StorageProviderFactory<FileSystemStorag
         private const val KB_FACTOR: Long = 1024
         private const val MB_FACTOR = 1024 * KB_FACTOR
         private const val GB_FACTOR = 1024 * MB_FACTOR
+        private val DEFAULT_FILE_PERMISSIONS = PosixFilePermissions.fromString("rw-------")
 
         /**
          * @param rootDirectory root directory of storage space
          * @param quota quota to use as % or in bytes
          */
-        fun of(journalist: Journalist, rootDirectory: Path, quota: String): FileSystemStorageProvider =
+        fun of(
+            journalist: Journalist,
+            rootDirectory: Path,
+            quota: String,
+            filePermissions: Set<PosixFilePermission> = DEFAULT_FILE_PERMISSIONS,
+        ): FileSystemStorageProvider =
             if (quota.endsWith("%")) {
                 of(
                     journalist = journalist,
                     rootDirectory = rootDirectory,
                     maxPercentage = quota.substring(0, quota.length - 1).toInt() / 100.0,
+                    filePermissions = filePermissions,
                 )
             } else {
                 of(
                     journalist = journalist,
                     rootDirectory = rootDirectory,
                     maxSize = displaySizeToBytesCount(quota),
+                    filePermissions = filePermissions,
                 )
             }
 
@@ -54,23 +64,56 @@ class FileSystemStorageProviderFactory : StorageProviderFactory<FileSystemStorag
          * @param rootDirectory root directory of storage space
          * @param maxSize the largest amount of storage available for use, in bytes
          */
-        fun of(journalist: Journalist, rootDirectory: Path, maxSize: Long): FileSystemStorageProvider =
+        fun of(
+            journalist: Journalist,
+            rootDirectory: Path,
+            maxSize: Long,
+            filePermissions: Set<PosixFilePermission> = DEFAULT_FILE_PERMISSIONS,
+        ): FileSystemStorageProvider =
             FixedQuota(
                 journalist = journalist,
                 rootDirectory = rootDirectory,
                 maxSize = maxSize,
+                filePermissions = filePermissions,
             )
 
         /**
          * @param rootDirectory root directory of storage space
          * @param maxPercentage the maximum percentage of the disk available for use
          */
-        fun of(journalist: Journalist, rootDirectory: Path, maxPercentage: Double): FileSystemStorageProvider =
+        fun of(
+            journalist: Journalist,
+            rootDirectory: Path,
+            maxPercentage: Double,
+            filePermissions: Set<PosixFilePermission> = DEFAULT_FILE_PERMISSIONS,
+        ): FileSystemStorageProvider =
             PercentageQuota(
                 journalist = journalist,
                 rootDirectory = rootDirectory,
                 maxPercentage = maxPercentage,
+                filePermissions = filePermissions,
             )
+
+        fun parseFilePermissions(value: String): Set<PosixFilePermission> {
+            val trimmed = value.trim()
+            val normalized = if (trimmed.length == 4 && trimmed.startsWith("0")) trimmed.substring(1) else trimmed
+            require(normalized.matches(Regex("[0-7]{3}"))) {
+                "File permissions must be an octal value with three digits (for example: 644)"
+            }
+
+            val mode = normalized.toInt(8)
+            val permissions = mutableSetOf<PosixFilePermission>()
+            if ((mode and 256) != 0) permissions += PosixFilePermission.OWNER_READ
+            if ((mode and 128) != 0) permissions += PosixFilePermission.OWNER_WRITE
+            if ((mode and 64) != 0) permissions += PosixFilePermission.OWNER_EXECUTE
+            if ((mode and 32) != 0) permissions += PosixFilePermission.GROUP_READ
+            if ((mode and 16) != 0) permissions += PosixFilePermission.GROUP_WRITE
+            if ((mode and 8) != 0) permissions += PosixFilePermission.GROUP_EXECUTE
+            if ((mode and 4) != 0) permissions += PosixFilePermission.OTHERS_READ
+            if ((mode and 2) != 0) permissions += PosixFilePermission.OTHERS_WRITE
+            if ((mode and 1) != 0) permissions += PosixFilePermission.OTHERS_EXECUTE
+            return permissions
+        }
 
         private fun displaySizeToBytesCount(displaySize: String): Long {
             val match = DISPLAY_SIZE_PATTERN.matcher(displaySize)
@@ -97,6 +140,7 @@ class FileSystemStorageProviderFactory : StorageProviderFactory<FileSystemStorag
         repositoryName: String,
         settings: FileSystemStorageProviderSettings,
     ): FileSystemStorageProvider {
+        val filePermissions = parseFilePermissions(settings.filePermissions)
         val repositoryDirectory =
             if (settings.mount.isEmpty())
                 workingDirectory.resolve(repositoryName)
@@ -109,6 +153,7 @@ class FileSystemStorageProviderFactory : StorageProviderFactory<FileSystemStorag
             journalist = journalist,
             rootDirectory = repositoryDirectory,
             quota = settings.quota,
+            filePermissions = filePermissions,
         )
     }
 

--- a/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemStorageProviderSettings.kt
+++ b/reposilite-backend/src/main/kotlin/com/reposilite/storage/filesystem/FileSystemStorageProviderSettings.kt
@@ -28,4 +28,6 @@ data class FileSystemStorageProviderSettings(
     val quota: String = "100%",
     @get:Doc(title = "Mount", description = "Use custom directory to locate the repository data (optional, by default it's './repositories/{name}')")
     val mount: String = "",
+    @get:Doc(title = "File permissions", description = "POSIX permissions for files created by this provider, in octal format (for example: 644; by default: 600)")
+    val filePermissions: String = "600",
 ) : StorageProviderSettings


### PR DESCRIPTION
In `fs` mode, files created in Maven repositories have POSIX permissions of 600 on Linux systems.
Therefore, I added a `File permissions` option to the Maven tab to control the permissions of newly created files.